### PR TITLE
chore(longhorn): set nodeDrainPolicy to block-for-eviction-if-contains-last-replica

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/values.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/values.yaml
@@ -34,6 +34,7 @@ defaultSettings:
   # replicaDiskSoftAntiAffinity: false
 
   allowEmptyDiskSelectorVolume: true
+  nodeDrainPolicy: block-for-eviction-if-contains-last-replica
 ingress:
   enabled: true
   ingressClassName: internal


### PR DESCRIPTION
## Problem

During Talos/Kubernetes node upgrades, the Longhorn `instance-manager` PodDisruptionBudget blocks node draining. Each node gets an instance-manager PDB with `minAvailable: 1`, but since there's exactly one instance-manager per node, `disruptionsAllowed: 0` — the eviction API can never evict it, causing the drain (and upgrade) to fail.

## Fix

Set `nodeDrainPolicy: block-for-eviction-if-contains-last-replica` in Longhorn's default settings.

With this policy:
- **If a volume's last replica is on the draining node** → Longhorn migrates that replica to another node first, then removes the PDB
- **If replicas exist on other nodes** (the normal case with `defaultReplicaCount: 2`) → the instance-manager PDB is removed immediately, drain proceeds cleanly

This means future tuppr-managed upgrades will complete without requiring manual intervention to delete the instance-manager pod.