### PR TITLE
feat(observability): add OTLP pipeline and Tempo forwarding to alloy-proxy

### DIFF
--- a/kubernetes/apps/observability/alloy-proxy/helmrelease.yaml
+++ b/kubernetes/apps/observability/alloy-proxy/helmrelease.yaml
@@ -38,6 +38,15 @@ spec:
         name: &app alloy-configmap
         key: config.alloy
       enableReporting: false
+      extraPorts:
+        - name: otlp-grpc
+          port: 4317
+          targetPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          port: 4318
+          targetPort: 4318
+          protocol: TCP
 
     controller:
       podAnnotations:

--- a/kubernetes/apps/observability/alloy-proxy/kustomization.yaml
+++ b/kubernetes/apps/observability/alloy-proxy/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./helmrelease.yaml
   - ./definition.yaml
   - ./loki-headless.yaml
+  - ./tempo-headless.yaml
   - ./probes.yaml
   - ./prometheusrule.yaml
 configMapGenerator:

--- a/kubernetes/apps/observability/alloy-proxy/resources/config.alloy
+++ b/kubernetes/apps/observability/alloy-proxy/resources/config.alloy
@@ -151,3 +151,87 @@ loki.write "default" {
     url = "http://loki-headless.observability.svc.cluster.local:3100/loki/api/v1/push"
   }
 }
+
+// ── OpenTelemetry Pipeline ──────────────────────────────────────────────────
+
+// Receive OTLP signals from pods in-cluster
+otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
+  output {
+    metrics = [otelcol.processor.attributes.default.input]
+    logs    = [otelcol.processor.attributes.default.input]
+    traces  = [otelcol.processor.attributes.default.input]
+  }
+}
+
+// Inject cluster/environment labels onto all signals
+otelcol.processor.attributes "default" {
+  action {
+    key    = "cluster"
+    value  = "${CLUSTER_CNAME}"
+    action = "insert"
+  }
+  action {
+    key    = "environment"
+    value  = "homelab"
+    action = "insert"
+  }
+  action {
+    key    = "region"
+    value  = "home"
+    action = "insert"
+  }
+  output {
+    metrics = [otelcol.processor.batch.default.input]
+    logs    = [otelcol.processor.batch.default.input]
+    traces  = [otelcol.processor.batch.default.input]
+  }
+}
+
+// Batch signals before forwarding
+otelcol.processor.batch "default" {
+  output {
+    metrics = [otelcol.exporter.prometheus.default.input]
+    logs    = [otelcol.exporter.loki.default.input]
+    traces  = [otelcol.exporter.otlphttp.tempo.input]
+  }
+}
+
+// OTLP metrics → forward to Equestria via thanos-receive ExternalName service
+otelcol.exporter.prometheus "default" {
+  forward_to = [prometheus.remote_write.equestria.receiver]
+}
+
+prometheus.remote_write "equestria" {
+  endpoint {
+    url = "http://thanos-receive.observability.svc.cluster.local:19291/api/v1/receive"
+    queue_config {
+      max_samples_per_send = 10000
+    }
+  }
+  external_labels = {
+    cluster     = "${CLUSTER_CNAME}",
+    environment = "homelab",
+    region      = "home",
+  }
+}
+
+// OTLP logs → Equestria Loki (via loki-headless ExternalName service)
+otelcol.exporter.loki "default" {
+  forward_to = [loki.write.default.receiver]
+}
+
+// OTLP traces → Equestria Tempo (via tempo-headless ExternalName service)
+otelcol.exporter.otlphttp "tempo" {
+  client {
+    endpoint = "http://tempo-headless.observability.svc.cluster.local:4318"
+    tls {
+      insecure = true
+    }
+  }
+}

--- a/kubernetes/apps/observability/alloy-proxy/tempo-headless.yaml
+++ b/kubernetes/apps/observability/alloy-proxy/tempo-headless.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.2/service.json
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/tailnet-fqdn: "tempo.${TAILSCALE_DOMAIN}"
+    tailscale.com/proxy-group: tailnet-inbound
+  name: tempo-headless
+spec:
+  externalName: unused
+  type: ExternalName
+  ports:
+    - port: 4318
+      targetPort: 4318
+      name: otlp-http


### PR DESCRIPTION
## Summary

### alloy-proxy OTLP Pipeline
- Append OTLP pipeline to alloy-proxy config: receiver → attributes → batch → Thanos/Loki/Tempo
- Expose OTLP ports 4317/4318 on alloy-proxy HelmRelease

### Tempo ExternalName Service
- New `tempo-headless.yaml`: ExternalName Service with Tailscale annotation pointing to Equestria Tempo
- Added to alloy-proxy kustomization

## Merge Order
Merge equestria-cluster PR first (Tempo must be running before SGC forwards to it).