### PR TITLE
fix(mosquitto): use ECR mirror for main container image

### DIFF
--- a/kubernetes/apps/sgc/home/mosquitto/helmrelease.yaml
+++ b/kubernetes/apps/sgc/home/mosquitto/helmrelease.yaml
@@ -52,7 +52,7 @@ spec:
               - -c
               - exec mosquitto -c "/config/$(hostname).conf"
             image:
-              repository: eclipse-mosquitto
+              repository: public.ecr.aws/docker/library/eclipse-mosquitto
               tag: "2.0.22@sha256:914f529386804c8278a4e581526b9be5e1604df44b30daabc70aa97dcefe5268"
             probes:
               liveness:


### PR DESCRIPTION
## Problem

`sgc/mosquitto` StatefulSet has 0/2 pods ready:
- `mosquitto-0` is stuck in `Completed` state (exited cleanly with code 0 after ~45 minutes; last state showed exit code 139/SIGSEGV)
- `mosquitto-1` was never created — StatefulSets create pods sequentially and won't create `-1` until `-0` is `Running/Ready`

Additionally, the main container image used Docker Hub (`eclipse-mosquitto`) while the init container already uses the ECR mirror (`public.ecr.aws/docker/library/eclipse-mosquitto`). This inconsistency could cause image pull failures if Docker Hub rate limits are hit.

## Fix

Align the main `app` container image to use the same ECR public mirror as the init container. Both containers now use the same SHA digest (`914f529...`) from `public.ecr.aws/docker/library/eclipse-mosquitto`.

## Operational Fix Required (after merge)

The StatefulSet also needs a manual pod delete to recover from the current stuck state:

```bash
SGC=/path/to/stargate-command-cluster/kubeconfig
kubectl --kubeconfig $SGC delete pod -n sgc mosquitto-0
```

This forces the StatefulSet to recreate `mosquitto-0`. Once it enters `Running/Ready`, the StatefulSet will automatically create `mosquitto-1`.

## Investigation Notes

The root cause of mosquitto-0 exiting (code 0 or 139/SIGSEGV) is unclear — it may be a memory issue, a config problem, or an upstream bug in `eclipse-mosquitto:2.0.22`. This PR addresses the image registry consistency issue; a separate investigation into the crash may be needed if the pod continues to exit after recreation.