### PR TITLE
fix(dns): exec-based probes for technitium (ipvlan asymmetric routing)

### DIFF
--- a/kubernetes/apps/sgc/dns/technitium/helmrelease.yaml
+++ b/kubernetes/apps/sgc/dns/technitium/helmrelease.yaml
@@ -67,12 +67,16 @@ spec:
               - secretRef:
                   name: ${APP}-env
             probes:
+              # exec probes on purpose: kubelet-dialed tcpSocket probes source
+              # from the node's LAN IP (10.10.0.0/16), and the pod replies via
+              # the ipvlan net1 interface (asymmetric) — they always time out.
+              # Exec runs inside the pod and is immune to the extra interface.
               liveness: &probes
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
-                    port: &adminPort 5380
+                  exec:
+                    command: ["bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/5380"]
                   initialDelaySeconds: 15
                   periodSeconds: 30
                   timeoutSeconds: 5
@@ -82,8 +86,8 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket:
-                    port: *adminPort
+                  exec:
+                    command: ["bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/5380"]
                   initialDelaySeconds: 10
                   periodSeconds: 10
                   failureThreshold: 30
@@ -116,7 +120,7 @@ spec:
         controller: *app
         ports:
           admin:
-            port: *adminPort
+            port: 5380
             protocol: TCP
           cluster-https:
             port: 53443


### PR DESCRIPTION
With multus/net1 actually attaching now, kubelet tcpSocket probes (sourced from the node's 10.10.0.0/16 IP) get asymmetric replies via the ipvlan interface and always time out — pod never Ready, all services lose endpoints (which briefly degraded tailnet DNS once the nameserver rotation picked the new nodes up). Exec probes run in-pod and are immune. Live deployments already hot-patched; this makes it stick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)