### PR TITLE
feat(dns): LE certificates + memory headroom for technitium

### DIFF
--- a/kubernetes/apps/sgc/dns/technitium/certificate.yaml
+++ b/kubernetes/apps/sgc/dns/technitium/certificate.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.2/secret.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: technitium-pkcs12-password
+stringData:
+  # protects the pkcs12 keystore inside the technitium-tls secret; set as the
+  # per-node certificate password via the technitium API after joining
+  password: technitium
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/cert-manager.io/certificate_v1.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: technitium-tls
+spec:
+  secretName: technitium-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-production
+  commonName: ${CLUSTER_CNAME}.dns.${ROOT_DOMAIN}
+  dnsNames:
+    - ${CLUSTER_CNAME}.dns.${ROOT_DOMAIN}
+  keystores:
+    pkcs12:
+      create: true
+      passwordSecretRef:
+        name: technitium-pkcs12-password
+        key: password

--- a/kubernetes/apps/sgc/dns/technitium/definition.yaml
+++ b/kubernetes/apps/sgc/dns/technitium/definition.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   name: Technitium DNS
   category: ${CLUSTER_TITLE}
-  description: Primary Technitium DNS cluster node
-  url: &url https://${APP}.${CLUSTER_DOMAIN}
+  description: Technitium DNS cluster node
+  url: &url https://${CLUSTER_KEY}.dns.${ROOT_DOMAIN}:53443
   icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/technitium.png
   access_policy:
     groups:
@@ -17,7 +17,7 @@ spec:
     oauth2:
       clientType: confidential
       allowedRedirectUris:
-      - url: "https://${APP}.${ROOT_DOMAIN}/sso/callback"
+      - url: "https://${CLUSTER_KEY}.dns.${ROOT_DOMAIN}:53443/sso/callback"
       propertyMappings:
         - email
         - openid
@@ -25,8 +25,13 @@ spec:
       includeClaimsInIdToken: true
       subMode: user_email
   gatus:
-    - group: "Technitium DNS"
+    - group: ${CLUSTER_TITLE}
       url: *url
       method: GET
       conditions:
         - "[STATUS] < 400"
+    - group: ${CLUSTER_TITLE}
+      url: https://${CLUSTER_KEY}.dns.${ROOT_DOMAIN}
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/sgc/dns/technitium/helmrelease.yaml
+++ b/kubernetes/apps/sgc/dns/technitium/helmrelease.yaml
@@ -104,7 +104,7 @@ spec:
                 cpu: 50m
                 memory: 256Mi
               limits:
-                memory: 512Mi
+                memory: 1Gi
 
     defaultPodOptions:
       securityContext:
@@ -161,6 +161,11 @@ spec:
         existingClaim: ${APP}
         globalMounts:
           - path: /etc/dns
+      tls:
+        type: secret
+        name: technitium-tls
+        globalMounts:
+          - path: /etc/technitium/certs/${CLUSTER_CNAME}.dns.${ROOT_DOMAIN}
 
     route:
       admin:

--- a/kubernetes/apps/sgc/dns/technitium/kustomization.yaml
+++ b/kubernetes/apps/sgc/dns/technitium/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./externalsecret.yaml
+  - ./certificate.yaml
   - ./definition.yaml
   - ./macvlan-nad.yaml


### PR DESCRIPTION
Reworked per review: keeps the standalone L3 tailscale ingress (tailscale.com docs pattern) instead of a sidecar. Adds the cert-manager PKCS12 certificate (enables DoT/DoH/DoQ) and raises the memory limit to 1Gi (previous pod segfaulted during cluster sync at 512Mi). Pod-outbound cluster traffic (zone transfers, heartbeats) reaches the primary via its LAN A records + david-driscoll/home-operations#594 (53443 on the LAN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)