### PR TITLE
feat(dns): tailscale sidecar for in-cluster technitium

### DIFF
--- a/kubernetes/apps/sgc/dns/technitium/helmrelease.yaml
+++ b/kubernetes/apps/sgc/dns/technitium/helmrelease.yaml
@@ -105,6 +105,39 @@ spec:
                 memory: 256Mi
               limits:
                 memory: 1Gi
+          tailscale:
+            # Same shape as docker/_common/technitium/compose.yaml: the pod IS
+            # the tailnet node dns-<cluster>. technitium shares this network
+            # namespace, so its listeners (53, 853, 443, 53443) are reachable on
+            # the node's own tailscale IP — and, critically, its OUTBOUND
+            # cluster traffic (zone refresh, config sync, heartbeats) sources
+            # from that same registered IP. The operator's L3 ingress could only
+            # ever serve inbound.
+            image:
+              repository: tailscale/tailscale
+              tag: v1.98.9@sha256:f15d5d3f4a68773a853180b72496f70ba614b64de0878c43fe3da39fe0afba47
+            env:
+              TS_STATE_DIR: /var/lib/tailscale
+              TS_USERSPACE: "false"
+              TS_AUTH_ONCE: "true"
+              # leave pod DNS alone — technitium resolves via its own engine and
+              # the cluster resolver must stay intact for everything else
+              TS_ACCEPT_DNS: "false"
+              TS_HOSTNAME: dns-${CLUSTER_CNAME}
+              TS_EXTRA_ARGS: --advertise-tags=tag:dns
+              TS_AUTHKEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: tailscale-authkey
+                    key: authkey
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
 
     defaultPodOptions:
       securityContext:
@@ -125,42 +158,21 @@ spec:
           cluster-https:
             port: 53443
             protocol: TCP
-      # Dedicated per-service tailscale proxy (NOT a ProxyGroup/Tailscale
-      # Service — those cannot forward UDP today). Defined here rather than as
-      # a raw manifest so kustomize commonLabels cannot rewrite the selector.
-      # The device joins the tailnet as dns-<cluster> with tag:dns.
-      tailscale:
-        controller: *app
-        type: LoadBalancer
-        loadBalancerClass: tailscale
-        annotations:
-          tailscale.com/hostname: dns-${CLUSTER_CNAME}
-          tailscale.com/tags: tag:dns
-        ports:
-          dns-udp:
-            port: 53
-            protocol: UDP
-          dns-tcp:
-            port: 53
-            protocol: TCP
-          dot:
-            port: 853
-            protocol: TCP
-          doq:
-            port: 853
-            protocol: UDP
-          doh:
-            port: 443
-            protocol: TCP
-          admin-tls:
-            port: 53443
-            protocol: TCP
 
     persistence:
       config:
         existingClaim: ${APP}
         globalMounts:
           - path: /etc/dns
+      tailscale-state:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        storageClass: longhorn
+        advancedMounts:
+          technitium:
+            tailscale:
+              - path: /var/lib/tailscale
       tls:
         type: secret
         name: technitium-tls

--- a/kubernetes/apps/sgc/dns/technitium/kustomization.yaml
+++ b/kubernetes/apps/sgc/dns/technitium/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - ./helmrelease.yaml
   - ./externalsecret.yaml
   - ./certificate.yaml
+  - ./tailscale-authkey.yaml
   - ./definition.yaml
   - ./macvlan-nad.yaml

--- a/kubernetes/apps/sgc/dns/technitium/tailscale-authkey.yaml
+++ b/kubernetes/apps/sgc/dns/technitium/tailscale-authkey.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.2/secret.json
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tailscale-authkey
+  annotations:
+    # mirrored from tailscale-system by emberstack reflector (the source secret
+    # carries reflection-allowed=true)
+    reflector.v1.k8s.emberstack.com/reflects: tailscale-system/tailscale-authkey


### PR DESCRIPTION
Replaces the operator L3 ingress Service with a tailscale sidecar in the technitium pod (compose.yaml parity).

**Why** — evidence from sgc's log:
```
failed to refresh 'dns.driscoll.tech' Secondary zone from: celestia.dns.driscoll.tech (100.111.30.101)
  → DnsClient ... SOA IN: request timed out
Failed to sync server configuration from the Primary node
  → HttpClient.Timeout of 30 seconds elapsing
```
Pods can only route to the operator's egress ClusterIPs, but Technitium's cluster machinery dials peers at their **registered node IPs** (tailnet addresses) for zone refresh (DNS/53) and config sync (HTTPS/53443). Both time out, so config sync never runs and the zone never transfers — the DANE/TLSA failures were a downstream symptom of the resulting stale zone copy. Per-zone `primaryNameServerAddresses` pins to the LAN IP are reset by the cluster catalog, and the primary's registered IP list can't be amended without re-initializing the cluster.

With the sidecar the pod *is* `dns-<cluster>`: it reaches any tailnet peer directly and its outbound traffic sources from its own registered IP. Inbound is unchanged (technitium shares the netns, so 53/853/443/53443 are served on the tailscale IP).

- Auth via the existing `tailscale-system/tailscale-authkey`, mirrored into `network` by emberstack reflector
- Tailscale state on its own PVC so the device identity (and its pinned IP) survives restarts
- multus ipvlan LAN VIP, LE certs, and exec probes all unchanged

After merge I will delete the old operator proxy devices, then rename/pin the sidecar devices to dns-sgc @ 100.111.209.205 and dns-equestria @ 100.111.206.205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)