### PR TITLE
fix(idp): dedupe duplicate authentik HelmRepository

### DIFF
--- a/kubernetes/apps/sgc/idp/authentik-remote-cluster/helmrelease.yaml
+++ b/kubernetes/apps/sgc/idp/authentik-remote-cluster/helmrelease.yaml
@@ -1,14 +1,4 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: authentik
-spec:
-  interval: 1h
-  url: https://charts.goauthentik.io/
-  timeout: 3m
----
 # yaml-language-server: $schema=https://kubernetes-schemas.18b.haus/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -22,4 +12,5 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: authentik
+        namespace: flux-system
   interval: 2h

--- a/kubernetes/apps/sgc/idp/authentik/helmrelease.yaml
+++ b/kubernetes/apps/sgc/idp/authentik/helmrelease.yaml
@@ -1,14 +1,4 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: authentik
-spec:
-  interval: 1h
-  url: https://charts.goauthentik.io/
-  timeout: 3m
----
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -23,6 +13,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: authentik
+        namespace: flux-system
   maxHistory: 3
   interval: 1h
   timeout: 20m

--- a/kubernetes/flux/meta/repos/authentik.yaml
+++ b/kubernetes/flux/meta/repos/authentik.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: authentik
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.goauthentik.io/
+  timeout: 3m

--- a/kubernetes/flux/meta/repos/kustomization.yaml
+++ b/kubernetes/flux/meta/repos/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./1password.yaml
+  - ./authentik.yaml
   - ./external-dns.yaml
   - ./tailscale.yaml
   - ./traefik.yaml


### PR DESCRIPTION
Removes the duplicate `authentik` HelmRepository. Investigation: david-driscoll/vault#104.

### The defect

Two separate app directories each declared their own HelmRepository named `authentik`, with the identical URL, both landing in the same target namespace (`sgc`):

- `kubernetes/apps/sgc/idp/authentik/helmrelease.yaml:9`
- `kubernetes/apps/sgc/idp/authentik-remote-cluster/helmrelease.yaml:9`

Two Flux Kustomizations (both `prune: true`) therefore claimed ownership of the same object.

Renovate's flux manager resolves a chart's `sourceRef` by matching every HelmRepository with the same name + namespace (`resolveHelmRepository`, `lib/modules/manager/flux/extract.ts`), so it collected both and produced a two-element `registryUrls`. The `helm` datasource inherits `registryStrategy: 'first'`, whose `firstRegistry()` warns and drops the rest — which is the Repository Problem on the dashboard (david-driscoll/stargate-command-cluster#6):

```
WARN: Excess registryUrls found for datasource lookup - using first configured only
{ "datasource": "helm", "packageName": "authentik-remote-cluster",
  "registryUrls": ["https://charts.goauthentik.io", "https://charts.goauthentik.io"] }
```

A repo-wide scan found this is the **only** duplicated HelmRepository name+namespace pair in the repo (21 declarations, 1 duplicate). `equestria-cluster` has 26 declarations and zero duplicates, which is exactly why the warning appears here and not there.

### The change

Moves the HelmRepository to `kubernetes/flux/meta/repos/authentik.yaml` — the repo's existing home for HelmRepositories shared across apps (`1password`, `external-dns`, `tailscale`, `traefik`) — and points both HelmReleases at `namespace: flux-system`. One declaration, two references, no ownership conflict, no ordering dependency between the two `sgc/idp` Kustomizations.

### Notes for review

- **This does not fix the four stuck "pin" dashboard entries.** Those are a separate problem in the Renovate config; fix is david-driscoll/.github#1. The lookup warning was benign as suspected — both URLs were identical, so `firstRegistry()` picked the right one and the `authentik` / `authentik-remote-cluster` chart versions resolved correctly. It is worth fixing on its own merits (the dual Kustomization ownership is the real bug), but it is not feeding the pin behaviour.
- **Sync side effect:** `kubernetes/flux/` is mirrored to `equestria-cluster` by `.github/equestria-sync.yaml`, so `authentik.yaml` will appear there too. Harmless — equestria's `authentik-remote-cluster` keeps its own in-namespace HelmRepository and will not match the new `flux-system` one — but that repo could later be pointed at it to drop its inline copy.
- Applying this prunes the `sgc/authentik` HelmRepository and re-points both HelmReleases at `flux-system/authentik`; expect a short reconcile as the source is re-resolved.
