### PR TITLE
feat(observability): deploy intel-gpu-exporter DaemonSet

### DIFF
--- a/kubernetes/apps/observability/intel-gpu-exporter/helmrelease.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/helmrelease.yaml
@@ -1,0 +1,135 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app intel-gpu-exporter
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      intel-gpu-exporter:
+        type: daemonset
+        containers:
+          app:
+            image:
+              repository: ghcr.io/clambin/intel-gpu-exporter
+              tag: 0.7.1@sha256:0fb61d5266001731f8e57dc1e2ac9fc0b29788f3c33f536a7d43ba0ecdc6f20d
+            args:
+              # Sampling interval handed to `intel_gpu_top -s`. The exporter
+              # aggregates (medians) every sample it has seen since the last
+              # scrape, so this is the resolution of the engine-busy signal,
+              # not the scrape interval.
+              - --interval=5s
+            env:
+              TZ: ${TIMEZONE}
+            securityContext:
+              # Least privilege, established empirically top-down (vault#110).
+              # Three independent gates have to be satisfied to read the i915 PMU:
+              #
+              #  1. capability — intel_gpu_top calls perf_event_open(2) for
+              #     system-wide (task == NULL) i915 PMU events. With
+              #     kernel.perf_event_paranoid > 0 the kernel requires
+              #     perfmon_capable(), which CAP_PERFMON satisfies (>= 5.8; nodes
+              #     run 6.18.39-talos). CAP_SYS_ADMIN would also work and is
+              #     strictly wider, so it is deliberately NOT used.
+              #  2. seccomp — containerd's RuntimeDefault profile denies
+              #     perf_event_open UNLESS the container holds CAP_PERFMON or
+              #     CAP_SYS_ADMIN, in which case it is added to the allow list
+              #     (containerd contrib/seccomp/seccomp_default.go). Since Talos
+              #     sets defaultRuntimeSeccompProfileEnabled: true cluster-wide,
+              #     RuntimeDefault applies whether or not it is declared here, so
+              #     it is declared explicitly rather than left to look accidental.
+              #     If the PMU ever returns EPERM with the capability present,
+              #     the next step is seccompProfile: { type: Unconfined }, NOT a
+              #     wider capability set.
+              #  3. sysctl — kernel.perf_event_paranoid is 3 on every node
+              #     (Talos default; not overridden in talos/patches). Verified
+              #     the kernel is built WITHOUT
+              #     CONFIG_SECURITY_PERF_EVENTS_RESTRICT, so there is no
+              #     Debian/AOSP-style "paranoid > 2 blocks everyone" tier — the
+              #     mainline gates are all `&& !perfmon_capable()` and CAP_PERFMON
+              #     clears them. No Talos machine-config change is required.
+              #
+              # runAsUser 0 is required, not incidental: /dev/dri/card0 is
+              # crw------- root:root on Talos, so only uid 0 can open the card
+              # node. Running non-root would need CAP_DAC_OVERRIDE, which is
+              # wider than staying root with everything else dropped.
+              runAsUser: 0
+              runAsGroup: 0
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+                add: ["PERFMON"]
+              seccompProfile: { type: RuntimeDefault }
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /metrics
+                    port: 9100
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probe
+            resources:
+              requests:
+                cpu: 15m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+                # Grants /dev/dri access via the Intel device plugin, which runs
+                # with -enable-monitoring. This resource hands the pod EVERY GPU
+                # on the node and — unlike `gpu.intel.com/i915` — does not consume
+                # one of the shared transcode slots (5 per node on equestria,
+                # 2 on sgc) that plex/jellyfin/tdarr/stremio/dispatcharr contend
+                # for.
+                #
+                # DEPRECATION: upstream now prefers a unified
+                # `gpu.intel.com/monitoring` covering all KMD types. The deployed
+                # plugin still advertises i915_monitoring (confirmed in node
+                # allocatable on all 5 Intel nodes), so use what is advertised.
+                # Revisit when Renovate bumps intel-device-plugins.
+                gpu.intel.com/i915_monitoring: 1
+    defaultPodOptions:
+      # Only the Intel Quick Sync nodes (equestria: fluttershy, kerfuffle;
+      # sgc: milky-way, othalla, pegasus). The label is published by the Intel
+      # GPU plugin's NFD rules — verified present on exactly those five nodes
+      # and on neither AMD node.
+      nodeSelector:
+        intel.feature.node.kubernetes.io/gpu: "true"
+      # hostPID is deliberately NOT set, though upstream's README uses it.
+      # It is only needed for the per-client breakdown (intel_gpu_top reads
+      # /proc/*/fdinfo to attribute usage to processes), which powers
+      # gpumon_clients_count. Engine busyness, frequency, power and IMC
+      # bandwidth all come from the PMU and need no host PID namespace.
+      # gpumon_clients_count will therefore report 0 with an empty `name`
+      # label; that is an accepted trade for not exposing the host process
+      # table to this pod.
+    service:
+      metrics:
+        controller: *app
+        ipFamilyPolicy: PreferDualStack
+        ports:
+          metrics:
+            port: 9100
+    persistence:
+      # readOnlyRootFilesystem: true — igt-gpu-tools scratch space.
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/observability/intel-gpu-exporter/ks.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app intel-gpu-exporter
+  namespace: &namespace observability
+  labels:
+    app.kubernetes.io/name: *app
+    driscoll.dev/name: *app
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  path: ./kubernetes/apps/observability/intel-gpu-exporter
+  dependsOn:
+    - name: prometheus
+      namespace: observability
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace

--- a/kubernetes/apps/observability/intel-gpu-exporter/kustomization.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./servicemonitor.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/observability/intel-gpu-exporter/prometheusrule.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/prometheusrule.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: intel-gpu-exporter-rules
+spec:
+  groups:
+    - name: intel-gpu-exporter.rules
+      rules:
+        # Absence, not threshold. There is no baseline for what normal
+        # engine utilisation looks like on either silicon generation
+        # (0x46a6 Alder Lake-P on equestria, 0x46d4 Alder Lake-N on sgc),
+        # so any threshold picked today would be a guess. This needs no
+        # baseline: the correct value is "not empty".
+        #
+        # The failure it catches is the nasty one and is NOT covered by
+        # `up`: the pod is Running and being scraped successfully, but
+        # perf_event_open has started returning EPERM — a Talos upgrade
+        # tightening kernel.perf_event_paranoid, a containerd seccomp
+        # profile change, or an Intel device-plugin bump renaming the
+        # i915_monitoring resource. In every one of those cases the
+        # exporter serves /metrics happily and exports nothing.
+        #
+        # `up == 0` is deliberately NOT duplicated here — the standard
+        # ServiceMonitor machinery already pages for a dead target, and
+        # two alerts for one event is how alert fatigue starts.
+        - alert: IntelGpuMetricsAbsent
+          annotations:
+            summary: Intel GPU engine metrics have disappeared from this cluster.
+            description: >-
+              intel-gpu-exporter is not producing gpumon_engine_usage. If the
+              DaemonSet pods are Running and `up` is healthy, the i915 PMU is
+              refusing perf_event_open — check CAP_PERFMON, the seccomp
+              profile, kernel.perf_event_paranoid, and that
+              gpu.intel.com/i915_monitoring is still advertised by the
+              Intel device plugin.
+          expr: absent(gpumon_engine_usage)
+          for: 30m
+          labels:
+            severity: warning
+
+# Deliberately NOT in this iteration: MediaHardwareTranscodeFallback
+# ("Plex silently fell back to CPU"). It is a joint GPU/CPU condition with
+# two thresholds that cannot be guessed — "idle" is not zero on either
+# part, Plex burns real CPU during direct play too, and tdarr legitimately
+# pins the video engine for hours. It needs ~14 days of data, which is the
+# same soak window vault#84 needs for the capacity report, so it costs
+# nothing on the critical path. The label join it depends on is already
+# proven: see the `node` relabeling in servicemonitor.yaml.

--- a/kubernetes/apps/observability/intel-gpu-exporter/servicemonitor.yaml
+++ b/kubernetes/apps/observability/intel-gpu-exporter/servicemonitor.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: &app intel-gpu-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: *app
+      app.kubernetes.io/name: *app
+  endpoints:
+    - port: metrics
+      # Matches node-exporter. The exporter medians every intel_gpu_top sample
+      # taken since the previous scrape, so a coarse scrape does not lose peaks
+      # outright, it averages them — revisit if 60s proves too blunt for the
+      # transcode-burst question in vault#84.
+      interval: 60s
+      scrapeTimeout: 30s
+      path: /metrics
+      relabelings:
+        # `instance` = node name, matching how every other node-level exporter
+        # in this estate keys itself (node-exporter, smartctl-exporter).
+        - action: replace
+          regex: (.*)
+          replacement: $1
+          sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: instance
+        # `node` = node name. This one is load-bearing and is NOT redundant:
+        #
+        #  * cAdvisor (job=kubelet) labels series with `node`, but its `instance`
+        #    is <nodeIP>:10250. So `gpumon_* and on (instance) container_cpu_*`
+        #    silently returns nothing — verified empirically against equestria's
+        #    Prometheus. `and on (node)` joins. The planned
+        #    MediaHardwareTranscodeFallback rule depends on this.
+        #  * The upstream clambin dashboard already queries
+        #    gpumon_*{node=~"^$node$"}, so it works unmodified.
+        - action: replace
+          regex: (.*)
+          replacement: $1
+          sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: node
+      metricRelabelings:
+        # Drop `pod`: for a DaemonSet exporter the node is the identity and the
+        # pod name is pure churn. It also keeps the Thanos view sane —
+        # Prometheus' remoteWrite writeRelabelConfigs overwrite `instance` with
+        # `pod` whenever a `pod` label is present, which is why smartctl-exporter
+        # series arrive in Thanos keyed on a pod name instead of a node.
+        - action: labeldrop
+          regex: (pod)

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -12,5 +12,6 @@ resources:
   - ./prometheus-proxy/ks.yaml
   - ./alloy-proxy/ks.yaml
   - ./smartctl-exporter/ks.yaml
+  - ./intel-gpu-exporter/ks.yaml
   - ./blackbox-exporter/ks.yaml
   - ./priority-class/ks.yaml


### PR DESCRIPTION
sgc half of david-driscoll/vault#110. Equestria half — which also carries the AMD `drm` collector and the Grafana dashboards — is david-driscoll/equestria-cluster#2976, and **that PR holds the full write-up** of the AMD sysfs verification, the privilege escalation ladder, and the label-join proof.

**Not deployed.** Branch + PR only; nothing reconciled, no Talos config touched.

---

## Why sgc is not deferred

vault#84 Workstream G asks whether the merged cluster's GPUs can carry equestria's transcode load. Equestria transcodes on **Alder Lake-P Iris Xe** (`0x46a6`, 20-vCPU/62 GiB hosts). Post-merge it would transcode on these three nodes' **Alder Lake-N UHD** (`0x46d4`, 4-vCPU/15.3 GiB hosts).

Instrumenting equestria alone measures the numerator and leaves the denominator blank. **The sgc numbers are the answer**, so they need the same soak window starting at the same time.

Confirmed live on all three nodes:

| Node | `gpu.intel.com/i915` | `i915_monitoring` | device-id | `intel.feature.node.kubernetes.io/gpu` |
|---|---|---|---|---|
| `milky-way` | 2 | 1 | `0x46d4` | `true` |
| `othalla` | 2 | 1 | `0x46d4` | `true` |
| `pegasus` | 2 | 1 | `0x46d4` | `true` |

---

## Contents

`kubernetes/apps/observability/intel-gpu-exporter/` — **byte-identical** to equestria's (`diff -r` clean), matching how `smartctl-exporter` is already carried across both repos. Plus one line in `observability/kustomization.yaml`, which is cluster-specific and excluded from the file-sync.

`ghcr.io/clambin/intel-gpu-exporter:0.7.1@sha256:0fb61d52…` — MIT, released 2026-07-18, linux/amd64 only (all three nodes are amd64), digest-pinned in the shape Renovate already bumps.

## Privilege — verified on this cluster, not assumed from equestria

`privileged: true` was pre-approved as a fallback. **Not used.** Runs `cap_drop: [ALL]` + `cap_add: [PERFMON]`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `seccompProfile: RuntimeDefault`.

The two gates that could have differed between clusters were checked against sgc's own nodes:

- `kernel.perf_event_paranoid` is **3** on `milky-way`, same as equestria — Talos default, not overridden in `talos/patches/global/machine-sysctls.yaml`. It is **not** a blocker: `/proc/config.gz` confirms the kernel is built **without** `CONFIG_SECURITY_PERF_EVENTS_RESTRICT`, so mainline semantics apply, every paranoid gate in `perf_event_open` is `… && !perfmon_capable()`, and `CAP_PERFMON` clears them. **No Talos machine-config change, no rolling reboot, nothing in Roland's lane.**
- `defaultRuntimeSeccompProfileEnabled: true` is set on all three sgc nodes too, so `RuntimeDefault` applies whether declared or not. containerd's default profile allows `perf_event_open` *conditionally on `CAP_PERFMON`* ([`contrib/seccomp/seccomp_default.go:750-755`](https://github.com/containerd/containerd/blob/main/contrib/seccomp/seccomp_default.go)), so the combination is coherent. Declared explicitly rather than left implicit.
- `i915` PMU present in `/sys/bus/event_source/devices/` on `milky-way`.

## Alerts

`IntelGpuMetricsAbsent` — `absent(gpumon_engine_usage)`, `for: 30m`, `warning`. Absence, not threshold: no baseline exists for `0x46d4` and a guessed threshold on a brand-new signal is how alert fatigue starts. `up == 0` deliberately excluded (already covered; duplicating it double-pages).

sgc runs a real Prometheus (`observability/prometheus`, v3.13.2) that already evaluates `smartctl-exporter`'s `PrometheusRule`, so this rule lands on the same path with no extra wiring.

## No dashboards

sgc has no Grafana. Metrics reach equestria's Thanos over the existing remote-write, and the dashboards in equestria#2976 carry a `cluster` variable so they render both clusters. Flagging explicitly so "nearly identical to equestria" does not later turn into a mechanical copy that drags a `GrafanaDashboard` into a cluster with no operator to consume it.

## Validation

- `flate test all` — **178 passed**, no new warnings.
- `yamllint` clean against the repo's `.yamllint`.
- `helm template` against app-template 5.0.1 renders the intended `DaemonSet`.

## Merge-order note

`.github/sgc-sync.yaml` (in the equestria repo) mirrors `kubernetes/apps/observability/` here, excluding `kustomization.yaml` and the cluster-specific subdirectories — `intel-gpu-exporter/` is **not** excluded. Because the directory here is byte-identical, the sync bot has nothing to do and merge order does not matter.

Refs david-driscoll/vault#110

<!-- crew:agent=oracle -->
