### PR TITLE
feat(tailscale): deploy tsiam workload identity alongside tsidp

### DIFF
--- a/kubernetes/apps/tailscale-system/iam/definition.yaml
+++ b/kubernetes/apps/tailscale-system/iam/definition.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/david-driscoll/stargate-command-cluster/refs/heads/main/schemas/definition.schema.json
+apiVersion: driscoll.dev/v1
+kind: ApplicationDefinition
+metadata:
+  name: tsiam
+spec:
+  name: Tailscale IAM
+  category: Infrastructure
+  description: >-
+    Tailscale-powered workload identity. Issues short-lived JWTs to machines
+    based on their tailnet node identity -- the machine-side counterpart to
+    tsidp, which authenticates humans.
+  url: https://tsiam.${TAILSCALE_DOMAIN}
+  icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/tailscale.svg
+  # Deliberately NO `authentik:` block. tsidp sits behind an authentik forward-auth
+  # proxy because its callers are browsers; tsiam's callers are machines holding no
+  # session, so a forward-auth proxy in front of it would break every token request.
+  # Authorization is tailnet ACL capabilities (`italypaleale.me/tsiam`), not SSO.
+  gatus:
+    - group: "Applications"
+      url: https://tsiam.${TAILSCALE_DOMAIN}/.well-known/openid-configuration
+      method: GET
+      conditions:
+        - "[STATUS] == 200"

--- a/kubernetes/apps/tailscale-system/iam/ks.yaml
+++ b/kubernetes/apps/tailscale-system/iam/ks.yaml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tsiam
+  namespace: &namespace tailscale-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+      driscoll.dev/name: *app
+  dependsOn:
+    - name: tailscale-operator
+      namespace: tailscale-system
+    - name: volsync
+      namespace: volsync-system
+  path: ./kubernetes/apps/tailscale-system/iam
+  prune: true
+  wait: true
+  force: false
+  interval: 1h
+  retryInterval: 2m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  components:
+    - ../../../components/failover/fast-node-eviction
+    - ../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      NAMESPACE: *namespace
+      # distroless nonroot uid/gid -- must match the pod securityContext so the
+      # restic mover restores the signing key with ownership tsiam can read.
+      VOLSYNC_PUID: "65532"
+      VOLSYNC_PGID: "65532"
+      # Named explicitly: this cluster has TWO default StorageClasses (longhorn and
+      # openebs-hostpath), so an unqualified PVC can silently land on non-replicated
+      # node-local storage. See david-driscoll/vault#113.
+      VOLSYNC_STORAGECLASS: longhorn
+      # A JWK and a tsnet state dir. Kilobytes, not gigabytes.
+      VOLSYNC_CAPACITY: 1Gi

--- a/kubernetes/apps/tailscale-system/iam/kustomization.yaml
+++ b/kubernetes/apps/tailscale-system/iam/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./tsiam.yaml
+  - ./definition.yaml

--- a/kubernetes/apps/tailscale-system/iam/tsiam.yaml
+++ b/kubernetes/apps/tailscale-system/iam/tsiam.yaml
@@ -1,0 +1,166 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app tsiam
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  maxHistory: 3
+  interval: 1h
+  timeout: 10m
+  install:
+    createNamespace: true
+    replace: true
+    remediation:
+      retries: 7
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      retries: 7
+      strategy: rollback
+  rollback:
+    force: false
+    cleanupOnFail: true
+    recreate: true
+  uninstall:
+    keepHistory: false
+  dependsOn: []
+  values:
+    controllers:
+      *app :
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: Recreate
+        pod:
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 30
+        containers:
+          *app :
+            nameOverride: *app
+            image:
+              repository: ghcr.io/italypaleale/tsiam
+              tag: v0.2.1@sha256:bb1959e85ce1fd7b5007589a3f23711cac2b9b46c852eef2c4d159de9c9bef94
+            env:
+              # tsiam has no env-var config surface of its own; everything lives in
+              # /etc/tsiam/config.yaml. TS_AUTHKEY is read by the embedded tsnet
+              # library itself (tailscale.com/tsnet), the same way tsidp consumes it.
+              TS_AUTHKEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: tailscale-authkey
+                    key: authkey
+            # tsiam serves *only* on its tsnet listener (:443 on the tailnet).
+            # There is no cluster-local port, so /healthz is unreachable from the
+            # kubelet and every probe type would be a false negative.
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+
+    defaultPodOptions:
+      securityContext:
+        # distroless/static-debian12:nonroot
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    configMaps:
+      config:
+        enabled: true
+        data:
+          config.yaml: |
+            tsnet:
+              hostname: tsiam
+              # tsnet's own node state (node key, machine key). Must be writable and
+              # must survive restarts, otherwise the node re-registers on every boot.
+              stateDir: /var/lib/tsiam/tsnet
+              ephemeral: false
+              # NOTE: no advertiseTags. The shared `tailscale-authkey` Secret is a
+              # pre-tagged key (tag:apps, same key `idp` uses); tsnet cannot advertise
+              # tags that the auth key does not already own. See the PR for the
+              # dedicated `tag:tsiam` key follow-up.
+              #
+              # Funnel stays OFF: this estate has no public ingress at all (no 80/443
+              # forward on the gateway) and nothing currently needs to verify these
+              # tokens from outside the tailnet. Turning it on would be a brand new
+              # public exposure surface.
+              funnel: false
+
+            tokens:
+              lifetime: 5m
+              # REQUIRED and must be non-empty -- tsiam refuses to start otherwise.
+              # This is a deliberate placeholder (RFC 2606 reserved TLD, can never
+              # resolve to anything real). Replace it with the real audience(s) when
+              # an actual consumer exists.
+              #
+              # Nothing can obtain a token today regardless of this list: with
+              # allowEmptyNodeCapability=false and no `italypaleale.me/tsiam` grants
+              # in the tailnet policy, every /token request is rejected.
+              allowedAudiences:
+                - "https://placeholder.invalid"
+              allowEmptyNodeCapability: false
+              rateLimitPerMinute: 60
+              # Stable Tailscale node ID. Never "name": node names are reusable once a
+              # device is deleted, so a relying party keyed on a name can be silently
+              # re-targeted by the next device that claims it.
+              subjectClaim: nodeId
+
+            signingKey:
+              # "file", not "memory": in-memory keys are regenerated on every restart,
+              # which rotates the JWKS and breaks every verifier (and every cached
+              # JWKS at a relying party) on each pod reschedule. Not "AzureKeyVault*"
+              # either -- the estate has no Azure footprint to anchor that to.
+              storage: file
+              algorithm: ES256
+              file:
+                storagePath: /var/lib/tsiam/signing-key.json
+
+            logs:
+              level: info
+              json: true
+              omitHealthChecks: true
+
+    persistence:
+      # Signing key + tsnet node state. Backed up by VolSync (see ks.yaml) so the
+      # JWKS survives loss of the PVC.
+      data:
+        existingClaim: *app
+        globalMounts:
+          - path: /var/lib/tsiam
+      config:
+        type: configMap
+        # `identifier`, not `name`: the chart renders this ConfigMap as `tsiam`,
+        # not `tsiam-config`, and identifier resolution keeps the reference correct
+        # if that naming ever changes.
+        identifier: config
+        globalMounts:
+          - path: /etc/tsiam/config.yaml
+            subPath: config.yaml
+            readOnly: true
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/tailscale-system/kustomization.yaml
+++ b/kubernetes/apps/tailscale-system/kustomization.yaml
@@ -12,4 +12,5 @@ resources:
   - ./services/ks.yaml
   - ./resources/ks.yaml
   - ./idp/ks.yaml
+  - ./iam/ks.yaml
   # - ./taildrive/ks.yaml

--- a/kubernetes/apps/tailscale-system/services/tailscale.yaml
+++ b/kubernetes/apps/tailscale-system/services/tailscale.yaml
@@ -14,3 +14,22 @@ spec:
     - port: 443
       targetPort: 443
       name: https
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.34.2/service.json
+# Egress-only, exactly like the tsidp entry above: `tailnet-fqdn` + `proxy-group`.
+# NOT `tailscale.com/expose` -- an expose+proxy-group Service is the combination
+# that wedges in Terminating with a ghost tailnet device.
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/tailnet-fqdn: "tsiam.${TAILSCALE_DOMAIN}"
+    tailscale.com/proxy-group: tailnet-inbound
+  name: tsiam
+spec:
+  externalName: tsiam
+  type: ExternalName
+  ports:
+    - port: 443
+      targetPort: 443
+      name: https


### PR DESCRIPTION
Deploys [tsiam](https://github.com/ItalyPaleAle/tsiam) (MIT) to `tailscale-system` on stargate-command, **alongside** tsidp.

Tracking: david-driscoll/vault#115

## tsiam is not a replacement for tsidp

Please do not later "consolidate" these. They have different subjects:

| | subject | callers | authorization |
|---|---|---|---|
| **tsidp** | humans | browsers, OIDC clients | authentik / user groups |
| **tsiam** | machines | tailnet nodes, no session | tailnet ACL capabilities (`italypaleale.me/tsiam`) |

tsiam issues short-lived JWTs proving *a node's* tailnet identity — the Tailscale analogue of an AWS IAM role or an Azure managed identity. tsidp answers "which human is this?"; tsiam answers "which machine is this?".

This is also why `definition.yaml` has **no `authentik:` block** while tsidp's does. tsidp sits behind an authentik forward-auth proxy because its callers are browsers. Putting a forward-auth proxy in front of tsiam would break every token request, because its callers hold no session.

## Decisions, and why

### Published image — yes
`ghcr.io/italypaleale/tsiam`, tags `v0.1.0` → `v0.2.1`. Pinned to `v0.2.1@sha256:bb1959e8…`. Nothing needed to be built or hosted.

### Tailnet join — embedded tsnet, same as tsidp
tsiam's **only** listener is its tsnet listener on `:443` (`pkg/server/server.go`). There is no cluster-local port at all. So it joins the tailnet itself, as its own node named `tsiam`, via `TS_AUTHKEY` from the existing `tailscale-authkey` Secret — byte-for-byte the tsidp pattern. tsiam has no env-var config surface of its own; `TS_AUTHKEY` is read by the vendored `tailscale.com/tsnet` (v1.98.10) directly.

It does **not** sit behind the operator proxy. The `ts-tsidp-*` pod some people expect to be tsidp's own tailnet identity is actually a separate **egress** proxy, so in-cluster workloads can reach `idp.<tailnet>`. This PR adds the matching egress Service for tsiam, using the identical shape:

```yaml
tailscale.com/tailnet-fqdn: "tsiam.${TAILSCALE_DOMAIN}"
tailscale.com/proxy-group: tailnet-inbound
```

**No `tailscale.com/expose` anywhere.** `expose` + `proxy-group` on one Service is the combination that wedges in `Terminating` with a ghost tailnet device; egress via `tailnet-fqdn` + `proxy-group` is the proven, deadlock-free form already running for tsidp and ~20 other services.

Verified no `tsiam` hostname exists on the tailnet today.

### Key storage — `file` on a Longhorn PVC
- `memory` regenerates the signing key on every restart. That rotates the JWKS on each pod reschedule and breaks every verifier, including any relying party caching the JWKS. Unacceptable for an identity issuer.
- `AzureKeyVaultKeys` / `AzureKeyVaultSecrets` would introduce an Azure dependency and Azure credentials into an estate with no Azure footprint.
- So: `file`, at `/var/lib/tsiam/signing-key.json`, on the same PVC as the tsnet node state, backed up by VolSync exactly like tsidp's `/data`.

**`storageClassName` is named explicitly** (`VOLSYNC_STORAGECLASS: longhorn`). This cluster has two default StorageClasses — `longhorn` and `openebs-hostpath` — so an unqualified PVC can silently land on non-replicated node-local storage (david-driscoll/vault#113). `VOLSYNC_PUID`/`PGID` are `65532` to match the distroless-nonroot uid, so a restic restore lands with ownership tsiam can read.

### JWKS exposure — tailnet + in-cluster. **Funnel: no.**
Verifiers reach `/.well-known/jwks.json` over the tailnet, or in-cluster through the egress Service. Funnel would publish the discovery endpoints on the public internet, which is the *only* thing that requires it (off-tailnet verifiers like AWS STS or Entra ID workload identity federation).

This estate has **no public ingress at all** — no 80/443 forward on the gateway. Funnel would be a genuinely new public exposure surface, and nothing currently needs it. `funnel: false`. Recommend it stays that way until a cloud-federation consumer actually exists.

### No probes
`/healthz` is served only on the tsnet listener, so the kubelet cannot reach it, and the distroless image has no shell for an exec probe. Every probe type would be a guaranteed false negative, so all three are explicitly disabled rather than left to the chart defaults.

## Prerequisite secrets — **none created; nothing new is required**

- `tailscale-authkey` (namespace `tailscale-system`, key `authkey`) — **already exists**, reused.
- `Volsync Password` + Backblaze 1Password items — **already exist**, consumed via the standard `components/volsync`.

Two things must be filled in before tsiam is *useful*, and neither is a cluster-repo change. Both are detailed in vault#115:

1. **Tailnet ACL capability grants** (`italypaleale.me/tsiam`), managed from `home-operations`. With `allowEmptyNodeCapability: false`, every `/token` request is rejected until a grant exists.
2. **Real `allowedAudiences`.** The config ships `https://placeholder.invalid` (RFC 2606 reserved TLD, can never resolve) purely because tsiam refuses to start with an empty list.

Optional hardening, also in vault#115: the shared auth key is pre-tagged `tag:apps`, and tsnet cannot advertise tags its key does not own — so the tsiam node lands on `tag:apps` and grants use `dst: ["tag:apps"]`. A dedicated `tag:tsiam` key would tighten that, at the cost of a new 1Password item + ExternalSecret + `tagOwners` entry.

## Who consumes these tokens?

Unstated. I searched for the Coder / agent-workspace workload-identity work that would be the plausible first consumer and **could not find a corresponding issue** in `david-driscoll/vault` or any repo under `david-driscoll` — so I have deliberately not designed for it. Until a consumer exists tsiam runs inert: joins the tailnet, holds a stable signing key, serves its JWKS, refuses every token request.

## Validation

```
yamllint -c .yamllint kubernetes/apps/tailscale-system/      # clean
kustomize build kubernetes/apps/tailscale-system/iam         # ok
kustomize build --load-restrictor LoadRestrictionsNone \
  kubernetes/apps/tailscale-system                           # ok
helm template ... app-template 5.0.1 -f <values>             # ok
flate test all --path ./kubernetes/flux/cluster \
  --allow-missing-secrets                                    # 180 passed
```

`flate` confirms `Kustomization tailscale-system/tsiam` and `HelmRelease tailscale-system/tsiam`. The three reported warnings are pre-existing on `main` (external-secrets, alloy, tailscale-operator) and untouched here.

Helm rendering caught one real bug during authoring: `persistence.config` originally used `name: tsiam-config`, but app-template renders the ConfigMap as `tsiam`. Switched to `identifier: config`, which resolves correctly and stays correct if the naming changes.

## Not deployed

Branch and PR only. No reconcile triggered, no `main` commits, cluster access was read-only throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
