### PR TITLE
feat(database): enable barman-cloud WAL archiving and PITR (authentik has no PITR today)

### DIFF
--- a/kubernetes/apps/database/postgres/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres/app/helmrelease.yaml
@@ -8,7 +8,10 @@ spec:
   chart:
     spec:
       chart: cluster
-      version: 0.7.0
+      # 0.8.x is the first cluster chart that can emit a barmancloud.cnpg.io
+      # ObjectStore and wire the plugin into .spec.plugins. 0.7.0 only knows
+      # the deprecated in-core .spec.backup.barmanObjectStore.
+      version: 0.8.1
       sourceRef:
         kind: HelmRepository
         name: cloudnative-pg

--- a/kubernetes/apps/database/postgres/app/resources/values.yaml
+++ b/kubernetes/apps/database/postgres/app/resources/values.yaml
@@ -18,13 +18,23 @@ recovery:
     accessKey: "{{ .minio_username }}"
     secretKey: "{{ .minio_password }}"
 backups:
-  enabled: false
+  enabled: true
+  # `plugin` routes backups through plugin-barman-cloud (already deployed at
+  # v0.7.1) rather than the operator's in-core barmanObjectStore, which is
+  # deprecated upstream and slated for removal. This renders an
+  # ObjectStore/postgres-backups and attaches the plugin to the Cluster as the
+  # WAL archiver, which is what gives us continuous archiving and PITR.
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
   endpointURL: "{{ .minio_endpoint }}"
   provider: s3
   s3:
     region: "{{ .minio_region }}"
     bucket: "{{ .backblaze_bucket }}"
-    path: "/"
+    # Dedicated prefix so barman's base backups + WAL never share a namespace
+    # with the logical dumps or the `-restore` staging bucket.
+    path: "/barman/${CLUSTER_CNAME}"
     accessKey: "{{ .minio_username }}"
     secretKey: "{{ .minio_password }}"
   wal:
@@ -39,7 +49,9 @@ backups:
   - name: daily-backup
     schedule: "${POSTGRES_BACKUP_SCHEDULE:=0 0 16 * * *}"
     backupOwnerReference: self
-    method: barmanObjectStore
+    method: plugin
+    pluginConfiguration:
+      name: barman-cloud.cloudnative-pg.io
   retentionPolicy: "30d"
 cluster:
   instances: 3


### PR DESCRIPTION
Mirror of [equestria-cluster#2981](https://github.com/david-driscoll/equestria-cluster/pull/2981).
Prerequisite for the PostgreSQL 17 → 18 work tracked in
[david-driscoll/vault#114](https://github.com/david-driscoll/vault/issues/114).
**Do not merge until the preconditions below are satisfied.** No PostgreSQL version
change is in this PR.

## Why this cluster, given it is being retired

SGC is slated to fold into equestria under
[vault#84](https://github.com/david-driscoll/vault/issues/84), and my recommendation
on #114 is that **SGC should never be upgraded to PostgreSQL 18** — it should be
migrated as-is and decommissioned. That makes the version bump moot here, but it does
not make backups moot. The opposite:

- SGC hosts **`authentik`**, the estate's identity provider. If it is lost, access to
  most of the estate goes with it.
- The database that has to survive a cluster *migration* is exactly the one that most
  needs a verified, restorable backup — and the migration is the riskiest thing that
  will ever happen to it.
- `kubectl get objectstore.barmancloud.cnpg.io -A` returns **No resources found**
  here too. `plugin-barman-cloud` v0.7.1 has been deployed and idle.

Recovery today is the nightly `pg_dump` CronJob only. Unlike equestria, all three
databases here (`authentik`, `crowdsec`, `oxycloud`) do dump cleanly — but at a
24-hour RPO, with `--no-owner --no-privileges` so ownership and grants are not
captured, and with no off-site copy.

## What this does

| | |
|---|---|
| `helmrelease.yaml` | cloudnative-pg `cluster` chart **0.7.0 → 0.8.1** |
| `resources/values.yaml` | `backups.enabled: true`, `backups.method: plugin` |

Chart 0.7.0 has no `backups.method` and no `cluster.plugins` — it can only emit the
operator's deprecated in-core `.spec.backup.barmanObjectStore`. 0.8.x is the first
version that renders a `barmancloud.cnpg.io/v1 ObjectStore`, so the chart bump is a
hard requirement for the plugin that is already installed.

Produces `ObjectStore/postgres-backups` at `s3://<bucket>/barman/sgc` against the
Spike Minio with 30d retention, a `.spec.plugins` entry with `isWALArchiver: true`,
and a `ScheduledBackup` using `method: plugin`. Rationale for choosing Minio over
Backblaze — and the fact that this concentrates yet another recovery path on `spike`
— is written up on the equestria PR.

## Preconditions before merge

1. **Bucket exists and the prefix is writable.** The values reuse the
   `{{ .backblaze_bucket }}` name against the Spike Minio endpoint, mirroring the
   existing (never-exercised) `recovery:` block. Confirm that bucket exists on Minio
   and that `barman/sgc/` is writable with the `Spike Minio Access Token`
   credentials before merging.
2. **Sequence behind equestria.** Merge and verify
   [equestria-cluster#2981](https://github.com/david-driscoll/equestria-cluster/pull/2981)
   first. Same change, larger cluster, and it proves the bucket/prefix/credential
   path before it is applied to the cluster holding authentik.

## Blast radius

Adding `.spec.plugins` injects a sidecar into the instance pods, so **this triggers a
rolling restart of all three PostgreSQL instances**, ending in a switchover. On this
cluster that briefly interrupts authentik, and therefore SSO for everything behind
it. Worth doing outside of a window where anyone needs to log in.

PVCs are 40Gi with 3.7Gi used (10%); the three databases total well under a
gigabyte, so WAL volume and backlog headroom are not a concern.

`stopDelay: 1800` appears as a new chart 0.8.1 default and matches the operator's own
default, so behaviour is unchanged.

## Validation

- `flate test all --allow-missing-secrets` — 178 passed, no new warnings
- `yamllint -c .yamllint` on both changed files — clean
- Chart 0.8.1 rendered with real values on the equestria side; templates are shared

## Verify after merge

```bash
kubectl -n database get objectstore postgres-backups
kubectl -n database get backup     # first ScheduledBackup runs immediately
```

Then exercise a restore of `authentik` into a scratch cluster. An untested backup is
not a backup, and this is the database where finding that out the hard way is worst.
