### PR TITLE
fix(tailscale): add volsync-restore bootstrap RD so the tsiam PVC can bind

### DIFF
--- a/kubernetes/apps/tailscale-system/iam/ks.yaml
+++ b/kubernetes/apps/tailscale-system/iam/ks.yaml
@@ -30,6 +30,32 @@ spec:
   components:
     - ../../../components/failover/fast-node-eviction
     - ../../../components/volsync
+    # BOOTSTRAP ONLY -- REMOVE ONCE THE RESTORE HAS COMPLETED.
+    #
+    # components/volsync always stamps the app PVC with a dataSourceRef to a
+    # ReplicationDestination named ${APP}-dst, but the ReplicationDestination
+    # itself lives here, in components/volsync-restore. Without it the PVC is
+    # claimed by the VolSync volume populator, Longhorn stands down
+    # ("assuming an external populator will provision the volume"), and the
+    # populator waits forever for an object nothing creates -- so the PVC never
+    # binds and the pod never schedules. That is exactly what happened on the
+    # initial tsiam deploy (#1737).
+    #
+    # tsiam has no backup to restore: the restic repository at /repository/tsiam
+    # does not exist yet. That is fine and is the intended bootstrap path. The
+    # restic mover runs `ensure_initialized` (creating the repo) and then
+    # do_restore finds nothing, logs "No eligible snapshots found / No data will
+    # be restored", and exits 0. The result is an empty volume, a bound PVC, and
+    # an initialized repository for the ReplicationSource to back up into.
+    #
+    # Lifecycle from here (see components/volsync-restore/AGENTS.md):
+    #   1. RD restores (no-op), sets status.lastManualSync=restore-once, PVC binds.
+    #   2. The nightly volsync-restore-cleanup CronJob (03:30) deletes the
+    #      completed RD, cascading away the -dst-dest/-dst-cache PVCs.
+    #   3. This component MUST then be removed from this list, or Flux recreates
+    #      the RD every reconcile and fights the cleanup job -- the permanent
+    #      -dst-dest/-dst-cache pair is what caused the 2026-07 Longhorn incident.
+    - ../../../components/volsync-restore
   postBuild:
     substitute:
       APP: *app
@@ -44,3 +70,8 @@ spec:
       VOLSYNC_STORAGECLASS: longhorn
       # A JWK and a tsnet state dir. Kilobytes, not gigabytes.
       VOLSYNC_CAPACITY: 1Gi
+      # Both movers read this. It defaults to 2Gi in the ReplicationSource but
+      # 8Gi in the ReplicationDestination, so leaving it unset would provision an
+      # 8Gi replicated Longhorn cache volume to restore zero bytes. Restic only
+      # caches index/metadata here, and the payload is a JWK plus tsnet state.
+      VOLSYNC_CACHE_CAPACITY: 1Gi


### PR DESCRIPTION
Fixes the tsiam deploy from #1737, which has been stuck since it merged. Tracking: david-driscoll/vault#115.

## Symptom

```
pod  tsiam-777bf78847-bkf57   0/1  Pending   FailedScheduling: unbound immediate PersistentVolumeClaims
pvc  tsiam                    Pending  (39m)  storageClassName=longhorn
     Warning VolSyncPopulatorReplicationDestinationMissing:
       Unable to populate volume: ReplicationDestination.volsync.backube "tsiam-dst" not found
     Normal  ExternalProvisioning (x143): waiting for 'driver.longhorn.io' or an administrator
     Normal  Provisioning: Assuming an external populator will provision the volume
```

## Diagnosis

`components/volsync` **always** stamps the app PVC with a `dataSourceRef` to a ReplicationDestination named `${APP}-dst`, but the ReplicationDestination itself lives in a **separate** component, `components/volsync-restore`. #1737 included the first and not the second.

The consequence is a deadlock, not a slow start. Because the PVC carries a `dataSourceRef`, the VolSync volume populator claims it and Longhorn deliberately stands down. The populator then waits for `tsiam-dst`, which nothing in the repo creates. The PVC can never bind, so the pod can never schedule.

**tsidp is the control, and it confirms the diagnosis rather than contradicting it.** Its PVC carries the *identical* `dataSourceRef` to `tsidp-dst`:

```yaml
dataSourceRef: {apiGroup: volsync.backube, kind: ReplicationDestination, name: tsidp-dst}
```

and there is no `tsidp-dst` in the namespace today. It is Bound only because `tsidp-dst` *did* exist when the PVC was created on 2026-07-05, and was later reaped by the nightly `volsync-restore-cleanup` CronJob. The two apps' `ks.yaml` component lists are otherwise byte-identical (`fast-node-eviction` + `volsync`); the only real difference was that tsidp was bootstrapped correctly and tsiam was not.

So this is the **first-deploy bootstrap gap**, and `tsiam-dst` is exactly the name `components/volsync-restore` generates — not a hardcoded name nothing produces.

### The ReplicationSource is a symptom, not a second bug

`replicationsource/tsiam` shows no `LAST SYNC` purely because it is blocked on the same PVC (`status: SyncInProgress` since `00:14:27Z`, mover cannot mount an unbound `sourcePVC`). Its schedule is `0 14 * * *` and its first window is 14:00 UTC today. No independent misconfiguration.

## Why a bootstrap restore is correct even though tsiam has never been backed up

This was the part worth checking rather than assuming, since the RD is nominally a *restore* and there is nothing to restore. Verified against the VolSync 0.16.0 restic mover (`mover-restic/entry.sh`, the version running in `volsync-system`):

```
"restore")
    ensure_initialized     # restic init -- creates /repository/tsiam
    do_restore
```

and `do_restore`:

```
snapshot_id=$(select_restic_snapshot_to_restore)
if [[ -z ${snapshot_id} ]]; then
    echo "No eligible snapshots found"
    echo "=== No data will be restored ==="
```

It exits 0. An empty repository is a supported, no-op restore. The net effect is exactly what a brand-new app wants: an **empty volume**, a **bound PVC**, and an **initialized restic repository** for the ReplicationSource to back up into from 14:00 onward. So tsiam ends up genuinely covered by VolSync, not merely unblocked.

## Why this does not require recreating the PVC

`dataSourceRef` is immutable, and the estate has been bitten by that before — so this fix deliberately does not touch the PVC at all. It only adds the missing RD.

That is sufficient because the populator watches ReplicationDestinations and maps them back to waiting claims (`internal/controller/volumepopulator_controller.go`):

```go
Watches(&volsyncv1alpha1.ReplicationDestination{}, ... mapFuncReplicationDestinationToVolumePopulatorPVC)
...
// Only enqueue a reconcile request if our PVC for volume populator is not already bound
return filterRequestsOnlyUnboundPVCs(pvcList)
```

Creating `tsiam-dst` re-enqueues the existing Pending `tsiam` PVC. **No manual PVC deletion is expected.** See the fallback below if that turns out not to hold.

## Changes

- Add `../../../components/volsync-restore` to `kubernetes/apps/tailscale-system/iam/ks.yaml`, with a comment documenting the failure mode and the removal obligation.
- Pin `VOLSYNC_CACHE_CAPACITY: 1Gi`. Both movers read this variable, but it defaults to **8Gi** in the ReplicationDestination versus 2Gi in the ReplicationSource — leaving it unset would provision an 8Gi replicated Longhorn cache volume to restore zero bytes, on the cluster that had the 2026-07 storage incident.

## Follow-up required — this component must be removed again

Per `components/volsync-restore/AGENTS.md`, leaving it in place permanently is what caused that incident. Lifecycle:

1. RD restores (no-op), sets `status.lastManualSync: restore-once`, PVC binds, pod schedules.
2. The nightly `volsync-restore-cleanup` CronJob (03:30) deletes the completed RD, cascading away the `tsiam-dst-dest` / `tsiam-dst-cache` PVCs.
3. **A follow-up PR must remove `components/volsync-restore` from this list**, or Flux recreates the RD every reconcile and fights the cleanup job.

## Validation

```
yamllint -c .yamllint kubernetes/apps/tailscale-system/iam/                  # clean
flate test all --path ./kubernetes/flux/cluster --allow-missing-secrets      # 180 passed
```

The 3 `flate` warnings (external-secrets, alloy, tailscale-operator) are pre-existing on `main` and untouched.

Rendering the app with its components confirms the names line up:

| | |
|---|---|
| PVC `tsiam` `dataSourceRef.name` | `tsiam-dst` |
| Rendered RD `metadata.name` | `tsiam-dst` |

## Scope

Not bundled, deliberately. **equestria** has the byte-identical `components/volsync` + `components/volsync-restore` + `restore-cleanup` arrangement, so the same trap applies to any *new* volsync-backed app there — but equestria does not run tsiam and has no app currently carrying `volsync-restore`, so there is nothing to fix there today.

This also does not touch the two prerequisites in david-driscoll/vault#115 (tailnet ACL capability grants, real `allowedAudiences`). Those govern whether tsiam can *issue tokens*; this PR only gets it *running*. Expect it to come up healthy and refuse every `/token` request until vault#115 is closed out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
