### PR TITLE
fix(database): make postgres backup job fail when a database dump fails

### DIFF
--- a/kubernetes/apps/database/postgres/backups/resources/App.cs
+++ b/kubernetes/apps/database/postgres/backups/resources/App.cs
@@ -55,19 +55,25 @@ List<string> databases;
 }
 
 // Create individual database dumps
+var failed = new List<string>();
 foreach (var db in databases)
 {
+  var backupFile = Path.Combine(backupDir, $"{db}.sql.gz");
+  // Dump to a sibling temp file and only replace the existing backup once pg_dump
+  // has exited 0. Writing straight to backupFile truncates the last known-good
+  // dump before the new one is known to be valid.
+  var stagingFile = $"{backupFile}.tmp";
   try
   {
     var postgres = await GetItemByTitle($"{clusterKey}-{db}-postgres");
-    var connectionString = (await GetItemByTitle($"{clusterKey}-{db}-postgres")).Fields.Single(f => f.Label == "connection-string").Value.Dump();
+    var connectionString = postgres.Fields.Single(f => f.Label == "connection-string").Value.Dump();
     await using var dataSource = NpgsqlDataSource.Create(connectionString);
 
     Console.WriteLine($"Backing up database: {db}");
-    var backupFile = Path.Combine(backupDir, $"{db}.sql.gz");
     Directory.CreateDirectory(Path.GetDirectoryName(backupFile) ?? throw new InvalidOperationException("Failed to get directory name for backup file"));
 
-    await CreateDatabaseDump(postgres, db, backupFile);
+    await CreateDatabaseDump(postgres, db, stagingFile);
+    File.Move(stagingFile, backupFile, overwrite: true);
 
     if (File.Exists(backupFile))
     {
@@ -75,16 +81,29 @@ foreach (var db in databases)
     }
     else
     {
-      Console.WriteLine($"Failed to create backup for database: {db}");
+      Console.Error.WriteLine($"Failed to create backup for database: {db}");
+      failed.Add(db);
     }
   }
   catch (Exception ex)
   {
-    Console.WriteLine($"Error backing up database {db}: {ex.Message}");
+    Console.Error.WriteLine($"Error backing up database {db}: {ex.Message}");
+    failed.Add(db);
+  }
+  finally
+  {
+    if (File.Exists(stagingFile)) File.Delete(stagingFile);
   }
 }
 
-Console.WriteLine($"PostgreSQL backup completed successfully at {DateTime.UtcNow}");
+if (failed.Count > 0)
+{
+  Console.Error.WriteLine($"PostgreSQL backup FAILED at {DateTime.UtcNow}: {failed.Count} of {databases.Count} database(s) were not backed up: {string.Join(", ", failed)}");
+  return 1;
+}
+
+Console.WriteLine($"PostgreSQL backup completed successfully at {DateTime.UtcNow} ({databases.Count} databases)");
+return 0;
 
 // Helper methods
 async Task<List<string>> GetDatabases(NpgsqlDataSource dataSource)
@@ -123,16 +142,23 @@ async Task CreateDatabaseDump(FullItem postgres, string database, string outputF
   using var process = Process.Start(psi);
   if (process == null) throw new InvalidOperationException("Failed to start pg_dump process");
 
-  // Compress the output
-  using var fileStream = File.Create(outputFile);
-  using var gzipStream = new GZipStream(fileStream, CompressionMode.Compress);
+  // --verbose writes progress to stderr throughout the dump. Drain it concurrently
+  // with stdout: reading it only after the process exits deadlocks once the stderr
+  // pipe buffer fills, because pg_dump then blocks before it can finish writing stdout.
+  var errorTask = process.StandardError.ReadToEndAsync();
 
-  await process.StandardOutput.BaseStream.CopyToAsync(gzipStream);
+  // Compress the output
+  await using (var fileStream = File.Create(outputFile))
+  await using (var gzipStream = new GZipStream(fileStream, CompressionMode.Compress))
+  {
+    await process.StandardOutput.BaseStream.CopyToAsync(gzipStream);
+  }
+
   await process.WaitForExitAsync();
+  var error = await errorTask;
 
   if (process.ExitCode != 0)
   {
-    var error = await process.StandardError.ReadToEndAsync();
     throw new InvalidOperationException($"pg_dump failed: {error}");
   }
 }


### PR DESCRIPTION
Companion to david-driscoll/equestria-cluster#2984 — `App.cs` is byte-identical between the two repos and carries the same exit-code bug.

## The bug

The nightly logical backup wrapped each per-database `pg_dump` in `try`/`catch`, logged the exception, continued, then unconditionally printed `PostgreSQL backup completed successfully` and fell off the end of the program with exit 0. The CronJob reported `Complete` even when a database was never dumped, so Job-failure alerting had nothing to fire on.

On equestria that was hiding a database with **no backup coverage at all**. Here it is currently harmless — see below — but the failure mode is identical.

## Changes

`kubernetes/apps/database/postgres/backups/resources/App.cs`:

- **failed databases are collected**; a non-empty list logs to stderr and **exits 1**
- **dumps are staged.** Each dump goes to `<db>.sql.gz.tmp` and is moved into place only after `pg_dump` exits 0. `File.Create` truncated the previous good backup *before* the new dump was known to be valid, so a failure replaced a working backup with a plausible-looking broken one.
- **`pg_dump`'s stderr is drained concurrently** with stdout instead of after `WaitForExit`. `--verbose` writes progress to stderr throughout; once that pipe buffer fills, `pg_dump` blocks and the job hangs. Latent, not yet hit.
- a duplicate 1Password item fetch on the same line is dropped

The container command already runs under `set -eux` and `dotnet run` propagates the exit code, so a non-zero exit fails the Job with no manifest change.

## Why this repo needs only the code fix

The equestria failure was a per-app schema owned by `postgres` that the app's login role had no USAGE on. Checked all three databases here — every schema is owned by its app role and every app role has USAGE, so all three dump cleanly:

| database | schemas | owner | app role has USAGE |
|---|---|---|---|
| authentik | `public` (215 tables), `template` (0) | `pg_database_owner` / `authentik` | yes |
| crowdsec | `public` (0), `crowdsec` (0) | `crowdsec` | yes |
| oxycloud | `public` (0), `oxycloud` (0) | `oxycloud` | yes |

No SQL remediation is needed here.

## Validation

- `dotnet build App.cs` — clean
- `flate test all` — `178 passed · 2 blocked`, identical to the same run on the base commit (the 2 blocked need secrets unavailable locally)
- `yamllint -c .yamllint kubernetes/apps/database/postgres/` — clean

Nothing was applied to any cluster. All cluster reads were read-only.

## Not in scope, but noticed

`App.cs` calls `.Dump()` (Dumpify) on the connection string at lines 50 and 63, which prints **DB passwords into the CronJob's pod logs** on every run. Same in both repos; left alone to keep this reviewable.

<!-- crew:agent=seraph -->