### PR TITLE
fix(database): stop leaking postgres credentials into backup job logs

### DIFF
--- a/kubernetes/apps/database/postgres/backups/resources/App.cs
+++ b/kubernetes/apps/database/postgres/backups/resources/App.cs
@@ -3,7 +3,6 @@
 #:package gstocco.YamlDotNet.YamlPath@1.0.26
 #:package KubernetesClient@*
 #:package Microsoft.Extensions.Logging@10.*
-#:package Dumpify@0.7.0
 #:package Lunet.Extensions.Logging.SpectreConsole@1.2.0
 #:package ProcessX@1.5.6
 #:package 1Password.Connect.Sdk@1.0.4
@@ -13,7 +12,6 @@
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Text.Json;
-using Dumpify;
 using Npgsql;
 using OnePassword.Connect.Sdk;
 using OnePassword.Connect.Sdk.Models;
@@ -47,7 +45,9 @@ List<string> databases;
 {
   // Get list of databases
   var postgres = await GetItemByTitle("${CLUSTER_CNAME}-postgres-user");
-  var connectionString = postgres.Fields.Single(f => f.Label == "connection-string").Value.Dump();
+  // NEVER log this — the connection string embeds the plaintext password and
+  // pod stdout is shipped to Loki.
+  var connectionString = GetField(postgres, "connection-string");
   Console.WriteLine("Fetching list of databases...");
   await using var dataSource = NpgsqlDataSource.Create(connectionString);
   databases = await GetDatabases(dataSource);
@@ -66,10 +66,9 @@ foreach (var db in databases)
   try
   {
     var postgres = await GetItemByTitle($"{clusterKey}-{db}-postgres");
-    var connectionString = postgres.Fields.Single(f => f.Label == "connection-string").Value.Dump();
-    await using var dataSource = NpgsqlDataSource.Create(connectionString);
 
-    Console.WriteLine($"Backing up database: {db}");
+    // Host/port/user only — never the password or the full connection string.
+    Console.WriteLine($"Backing up database: {db} ({GetField(postgres, "username")}@{GetField(postgres, "hostname")}:{GetField(postgres, "port")})");
     Directory.CreateDirectory(Path.GetDirectoryName(backupFile) ?? throw new InvalidOperationException("Failed to get directory name for backup file"));
 
     await CreateDatabaseDump(postgres, db, stagingFile);


### PR DESCRIPTION
## Problem

`kubernetes/apps/database/postgres/backups/resources/App.cs` piped both PostgreSQL connection strings through Dumpify's `.Dump()`, which prints its argument to stdout:

```csharp
var connectionString = postgres.Fields.Single(f => f.Label == "connection-string").Value.Dump();
```

That happened twice — once for the cluster-wide `postgres-user` (line 50) and once per app database inside the backup loop (line 69). These connection strings embed plaintext passwords, so **every nightly `postgres-backup` CronJob run wrote the cluster postgres superuser password plus one set of app-database credentials per database into the pod's stdout**, where Alloy scrapes it into Loki and retains it.

## Fix

- Drop both `.Dump()` calls (leftover debugging) and the now-unused `Dumpify` package reference and `using`.
- The per-database progress line still says what is being backed up, but built from the discrete 1Password fields — `user@host:port` — never the password or the full connection string.
- Remove the `NpgsqlDataSource` constructed inside the backup loop: `CreateDatabaseDump` shells out to `pg_dump` and never used it, so it existed only to consume the leaked connection string.
- Add comments at both sites recording *why* these values must never be logged, so the pattern doesn't come back.

`Dumpify` is still referenced by `kubernetes/components/common/Update.cs` and `kubernetes/components/postgres/Update.cs`; only this script's reference is removed.

## Note on remediation

This stops the leak going forward. It does **not** scrub credentials already sitting in Loki — any password that appeared in these logs should be treated as exposed for the retention window and rotated separately.

## Cross-repo

This mirrors [equestria-cluster#2983](https://github.com/david-driscoll/equestria-cluster/pull/2983), which already landed there. After this PR, `App.cs` is byte-identical between the two clusters again (verified with `diff`).

Branched on top of #1740, which is already in `main`.

## Validation

- `dotnet build kubernetes/apps/database/postgres/backups/resources/App.cs` — succeeds.
- `flate test all` — 178 passed · 2 blocked. Identical to the `main` baseline; the 2 blocked (`network/cloudflare-tunnel`, `tailscale-system/tailscale-operator`) are pre-existing missing-secret cases, unrelated to this change.
- `yamllint -c .yamllint kubernetes/apps/database/postgres/` — clean. No YAML changed; `App.cs` reaches the cluster via `configMapGenerator`, so `flate test` covers the rendered ConfigMap.

Not applied to any cluster — Flux will pick it up on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- crew:agent=seraph -->