### PR TITLE
fix(tailscale): store tsiam's signing key in a subdir it can own

### DIFF
--- a/kubernetes/apps/tailscale-system/iam/ks.yaml
+++ b/kubernetes/apps/tailscale-system/iam/ks.yaml
@@ -30,32 +30,21 @@ spec:
   components:
     - ../../../components/failover/fast-node-eviction
     - ../../../components/volsync
-    # BOOTSTRAP ONLY -- REMOVE ONCE THE RESTORE HAS COMPLETED.
+    # NOTE: components/volsync-restore was here for the #1739 bootstrap and has
+    # now been removed -- its removal obligation is discharged. The RD completed
+    # (status.lastManualSync=restore-once, lastSyncTime 2026-08-02T01:16:01Z,
+    # "No eligible snapshots found / No data will be restored" -- the intended
+    # empty-volume bootstrap path), the PVC is Bound, and the ReplicationSource
+    # is backing up. Dropping the component prunes the RD and cascades away the
+    # volsync-tsiam-dst-dest / volsync-dst-tsiam-dst-cache pair, which is exactly
+    # what the nightly cleanup CronJob would have done at 03:30. Leaving it in
+    # would have Flux recreate the RD every reconcile and fight that job -- the
+    # permanent -dst-dest/-dst-cache pair caused the 2026-07 Longhorn incident.
     #
-    # components/volsync always stamps the app PVC with a dataSourceRef to a
-    # ReplicationDestination named ${APP}-dst, but the ReplicationDestination
-    # itself lives here, in components/volsync-restore. Without it the PVC is
-    # claimed by the VolSync volume populator, Longhorn stands down
-    # ("assuming an external populator will provision the volume"), and the
-    # populator waits forever for an object nothing creates -- so the PVC never
-    # binds and the pod never schedules. That is exactly what happened on the
-    # initial tsiam deploy (#1737).
-    #
-    # tsiam has no backup to restore: the restic repository at /repository/tsiam
-    # does not exist yet. That is fine and is the intended bootstrap path. The
-    # restic mover runs `ensure_initialized` (creating the repo) and then
-    # do_restore finds nothing, logs "No eligible snapshots found / No data will
-    # be restored", and exits 0. The result is an empty volume, a bound PVC, and
-    # an initialized repository for the ReplicationSource to back up into.
-    #
-    # Lifecycle from here (see components/volsync-restore/AGENTS.md):
-    #   1. RD restores (no-op), sets status.lastManualSync=restore-once, PVC binds.
-    #   2. The nightly volsync-restore-cleanup CronJob (03:30) deletes the
-    #      completed RD, cascading away the -dst-dest/-dst-cache PVCs.
-    #   3. This component MUST then be removed from this list, or Flux recreates
-    #      the RD every reconcile and fights the cleanup job -- the permanent
-    #      -dst-dest/-dst-cache pair is what caused the 2026-07 Longhorn incident.
-    - ../../../components/volsync-restore
+    # Re-add it (temporarily, same removal obligation) only if the tsiam PVC ever
+    # has to be rebuilt: components/volsync stamps the PVC with a dataSourceRef to
+    # a ReplicationDestination that only that component creates, so without it a
+    # fresh PVC never binds.
   postBuild:
     substitute:
       APP: *app

--- a/kubernetes/apps/tailscale-system/iam/tsiam.yaml
+++ b/kubernetes/apps/tailscale-system/iam/tsiam.yaml
@@ -82,7 +82,13 @@ spec:
         runAsNonRoot: true
         runAsUser: 65532
         runAsGroup: 65532
+        # fsGroup is load-bearing, not decoration: it is what makes the PVC root
+        # group-writable + setgid (0:65532 mode 2775) so tsiam can create and own
+        # its own subdirectories under /var/lib/tsiam. It cannot make tsiam own
+        # the root itself -- fsGroup never changes uid. See signingKey.file below.
         fsGroup: 65532
+        # OnRootMismatch, not Always: the walk is group-only either way, so Always
+        # buys nothing here and just re-chowns the tree on every mount.
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
@@ -136,7 +142,35 @@ spec:
               storage: file
               algorithm: ES256
               file:
-                storagePath: /var/lib/tsiam/signing-key.json
+                # A SUBDIRECTORY, never the volume mount root. tsiam's
+                # NewFileKeyStorage (pkg/keystorage/keystorage-file.go) does
+                # MkdirAll(dir, 0700) followed by an *unconditional* Chmod(dir, 0700)
+                # on filepath.Dir(storagePath), on every single start.
+                #
+                # chmod(2) requires the caller to own the file or hold CAP_FOWNER, and
+                # it enforces that before it compares modes -- so it fails even when
+                # the mode is already correct. This container drops ALL capabilities,
+                # so it must own the directory outright.
+                #
+                # It cannot own the mount root. fsGroup only ever chowns the *group*
+                # (kubelet calls chown(path, -1, fsGroup) and adds g+rwX plus setgid),
+                # so a freshly provisioned Longhorn volume roots at
+                # `0:65532 mode 2775` and stays uid 0 forever. Pointing storagePath at
+                # the root made tsiam chmod / that root and crash-loop on
+                # "chmod /var/lib/tsiam: operation not permitted" (see sgc#1739
+                # follow-up). fsGroupChangePolicy: Always does NOT help -- it re-runs
+                # the same group-only walk; verified against the live volume.
+                #
+                # Under a subdirectory it works without touching the security context:
+                # the root is 2775 and group-writable by fsGroup 65532, so tsiam
+                # creates `keys/` itself and therefore owns it, and the setgid bit
+                # carries gid 65532 down. This also survives a VolSync restore: the
+                # restic mover runs as VOLSYNC_PUID/PGID 65532, so a restored
+                # `keys/` comes back owned by 65532 too, while the mount root is
+                # re-created as uid 0 by the filesystem every time regardless.
+                #
+                # tsnet.stateDir above is a subdirectory for the same reason.
+                storagePath: /var/lib/tsiam/keys/signing-key.json
 
             logs:
               level: info


### PR DESCRIPTION
## What broke

sgc#1739 got `pvc/tsiam` to `Bound`, but tsiam then crash-looped 8 times:

```
{"level":"ERROR","msg":"Failed to get signing key",
 "error":"failed to get key storage: failed to init key storage 'file':
          failed to chmod key storage directory:
          chmod /var/lib/tsiam: operation not permitted"}
```

## What is actually on the volume

I mounted the PVC in a throwaway pod rather than reason from the manifests:

```
drwxrwsr-x  3 0  65532  4096  /var/lib/tsiam        <- 2775, uid 0, gid 65532
drwxrws---  2 0  65532 16384  /var/lib/tsiam/lost+found
```

Empty except `lost+found` — the restore was a no-op by design (`No eligible snapshots found / No data will be restored`).

## Root cause

`NewFileKeyStorage` ([`pkg/keystorage/keystorage-file.go`](https://github.com/ItalyPaleAle/tsiam/blob/v0.2.1/pkg/keystorage/keystorage-file.go#L22-L38)) runs an **unconditional** `Chmod(filepath.Dir(storagePath), 0700)` on every start. `storagePath` was `/var/lib/tsiam/signing-key.json`, so `dir` was the **volume mount root**.

`chmod(2)` requires ownership or `CAP_FOWNER`, and enforces that *before* comparing modes — so it fails even when the mode is already correct. tsiam drops `ALL` capabilities, so it must own the directory. It doesn't: the root is uid 0.

**`fsGroup` can never fix this.** The kubelet's fsGroup path calls `chown(path, -1, fsGroup)` and adds `g+rwX` plus setgid — group only, uid explicitly untouched. `0:65532 mode 2775` *is* the signature of fsGroup having been applied. A fresh Longhorn volume roots at uid 0 and stays there.

## Verification, not inference

In a pod with tsiam's exact security context (`runAsUser/Group 65532`, `fsGroup 65532`, `drop: [ALL]`, `readOnlyRootFilesystem`, `runAsNonRoot`):

```
chmod 0700 /var/lib/tsiam           -> Operation not permitted   (today's failure)
mkdir -p  /var/lib/tsiam/keys       -> ok
chmod 0700 /var/lib/tsiam/keys      -> ok  (drwx------ 65532:65532)
write     /var/lib/tsiam/keys/...   -> ok
```

And I tested the leading hypothesis instead of assuming it — a pod with **`fsGroupChangePolicy: Always`**:

```
drwxrwsr-x  5 0  65532  /var/lib/tsiam    <- still uid 0 after the remount
chmod 0700 /var/lib/tsiam -> Operation not permitted
```

**`Always` does not fix this.** Probe files were removed and all three debug pods deleted.

## The fix

Point `signingKey.file.storagePath` at a subdirectory: `/var/lib/tsiam/keys/signing-key.json`.

The root is `2775` and group-writable by `fsGroup` 65532, so tsiam creates `keys/` itself and therefore **owns** it, and the chmod succeeds. setgid carries gid 65532 down. `tsnet.stateDir` was already a subdirectory for the same reason. **No security context was weakened** — `runAsNonRoot`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem`, `seccompProfile` and `drop: [ALL]` are all untouched.

## Does it survive the next restore?

Yes, and it's the only option that does so without maintenance. The restic mover runs as `VOLSYNC_PUID/PGID` 65532, so a restored `keys/` comes back owned by 65532 (restoring ownership it already has is permitted for the owner). The mount root is re-created as uid 0 by the filesystem on every fresh volume regardless — which is exactly why the fix must not depend on owning it.

## Rejected alternatives

| Option | Why not |
|---|---|
| `fsGroupChangePolicy: Always` | **Does not work** — empirically tested above. Group-only walk; uid stays 0. |
| Align `runAsUser` with the owner | The owner is uid 0. That means running as root and abandoning `runAsNonRoot` and the distroless nonroot image. |
| Add `CAP_FOWNER` | Would work, but grants a blanket bypass of ownership permission checks to paper over one directory. Least preferred, and unnecessary. |
| Root initContainer that chowns | Needs a root container in a `runAsNonRoot` pod plus `CAP_CHOWN`, to fix something the app shouldn't do to a mount root anyway. |
| `subPath` on the volumeMount | Kubelet creates subPath dirs as root — mount root would still be uid 0. |

`tsidp` being looser was not treated as a justification for anything.

## Also: discharging #1739's removal obligation

`replicationdestination/tsiam-dst` is complete — `lastManualSync: restore-once`, `lastSyncTime: 2026-08-02T01:16:01Z`, `result: Successful` — and `replicationsource/tsiam` is backing up. The `volsync-tsiam-dst-dest` / `volsync-dst-tsiam-dst-cache` pair the component's `AGENTS.md` warns about currently exists.

So `components/volsync-restore` is **removed from `ks.yaml` in this PR**. Flux prunes the RD and cascades those two PVCs away — exactly what the nightly cleanup CronJob would do at 03:30, without the recreate-vs-cleanup fight that caused the 2026-07 Longhorn incident. A comment records how to re-add it if the PVC ever has to be rebuilt.

## Out of scope

vault#115 stays open — ACL capability grants and real `allowedAudiences` govern token *issuance*. This PR only gets the process to start.

Refs #1737, #1739

🤖 Generated with [Claude Code](https://claude.com/claude-code)
