### PR TITLE
fix(flux): remove the 100m CPU limit throttling SGC's controllers

### DIFF
--- a/docs/sgc-n1-resilience-plan-2026-07-04.md
+++ b/docs/sgc-n1-resilience-plan-2026-07-04.md
@@ -199,6 +199,16 @@ This phase alone makes both documented incidents non-repeatable.
 **Files:** `kubernetes/apps/flux-system/flux-instance/**`
 **Scope:** S
 
+> **⚠️ REVERSED 2026-08-02 — this task was based on a false premise. Do not re-apply it.** See [vault#118](https://github.com/david-driscoll/vault/issues/118).
+>
+> CPU **limits** play no part in scheduling or in eviction ranking — only **requests** do, and this task never touched requests. So the ~6c of CPU limits it removed were not distorting anything, and trimming them bought zero N-1 headroom.
+>
+> What it did buy was harm. The plan's own text suggested 500m; the commit shipped `cpu: 100m`, equal to the request, and the second acceptance box ("controllers stay Ready; reconciliation unaffected") was never ticked. Measured a month later, kustomize-controller was CFS-throttled up to **99.9%**, no-op Kustomization reconciles ran at **p95 103s** (equestria, uncapped, ~2× the tree: **p95 2.1s**), and the `/healthz` liveness probe (`timeoutSeconds: 1`, `failureThreshold: 3`) failed **14 times in 7 days** — each trio of failures SIGTERMing the container, which then re-reconciled all 77 Kustomizations and throttled itself again.
+>
+> The CPU limit on kustomize/helm/source-controller is now removed outright (`cpu: null`) rather than raised, because a CFS quota throttles a bursty reconciler even on a fully idle node. Requests are unchanged at 100m/50m, so the N-1 reservation math this plan cared about is untouched.
+>
+> The memory half of the task stands: `memory: 1Gi` was and is a real ceiling.
+
 #### Task 2.3: Right-size home-assistant memory limit
 **Description:** home-assistant limit is 6 GiB vs 816 MiB used. Lower to a realistic ceiling (e.g. 2 GiB) to reduce the oversized reservation footprint.
 **Acceptance criteria:**

--- a/kubernetes/apps/flux-system/flux-instance/helm/values.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/helm/values.yaml
@@ -20,7 +20,10 @@ instance:
     path: kubernetes/flux/cluster
   kustomize:
     patches:
-    - # Increase the number of workers
+    - # Increase the number of workers.
+      # Effective concurrency: helm/source-controller = 10; kustomize-controller = 20,
+      # because the "in-memory kustomize builds" patch below appends a second
+      # --concurrent and Go's flag package takes the last occurrence.
       patch: |
         - op: add
           path: /spec/template/spec/containers/0/args/-
@@ -31,7 +34,24 @@ instance:
       target:
         kind: Deployment
         name: (kustomize-controller|helm-controller|source-controller)
-    - # Increase the memory limits
+    - # Memory limits, and NO CPU limit.
+      #
+      # `cpu: null` deletes the upstream 1000m limit rather than lowering it.
+      # CPU limits are enforced by the CFS quota, which throttles inside every
+      # 100ms period even when the node is completely idle — so a limit on a
+      # bursty, latency-sensitive reconciler buys nothing and costs latency.
+      # CPU limits also play no part in scheduling; only requests do, which are
+      # left untouched here, so the N-1 reservation math is unaffected.
+      #
+      # History: this patch previously set `cpu: 100m` (== the request), added by
+      # the 2026-07-04 N-1 resilience plan on the premise that oversized limits
+      # "distort scheduling/eviction math". They do not — requests do. The result
+      # was a kustomize-controller pegged at 100m and CFS-throttled up to 99.9%,
+      # no-op Kustomization reconciles taking 1-3 minutes (p95 103s vs equestria's
+      # 2.1s at ~2x the tree), and 14 liveness-probe failures in 7 days. The probe
+      # (/healthz, timeoutSeconds 1, failureThreshold 3) cannot answer inside a
+      # throttled slice, so kubelet SIGTERMs the container; it exits 0/Completed
+      # and the whole tree re-reconciles, which throttles it again. See vault#118.
       patch: |
         apiVersion: apps/v1
         kind: Deployment
@@ -44,12 +64,16 @@ instance:
                 - name: manager
                   resources:
                     limits:
-                      cpu: 100m
+                      cpu: null
                       memory: 1Gi
       target:
         kind: Deployment
         name: (kustomize-controller|helm-controller|source-controller)
-    - # Enable in-memory kustomize builds
+    - # Enable in-memory kustomize builds.
+      # The temp dir is a tmpfs, so build scratch space is charged to this pod's
+      # memory cgroup. With the CPU limit gone these 20 workers actually run in
+      # parallel instead of queueing, so raise the ceiling above the 436Mi peak
+      # observed while they were serialised by throttling.
       patch: |
         - op: add
           path: /spec/template/spec/containers/0/args/-
@@ -60,6 +84,9 @@ instance:
             name: temp
             emptyDir:
               medium: Memory
+        - op: add
+          path: /spec/template/spec/containers/0/resources/limits/memory
+          value: 2Gi
       target:
         kind: Deployment
         name: kustomize-controller


### PR DESCRIPTION
Fixes the CPU cap that has kustomize-controller pegged and turns every controller restart into something that looks like a cluster-wide Flux outage.

Refs david-driscoll/vault#118.

## Why the cap exists — it was deliberate, but on a false premise

`git log -S "cpu: 100m"` points at one commit: `a8e55056b` *"feat: Implement N-1 resilience plan for SGC cluster"* (2026-07-05), Task 2.2 of `docs/sgc-n1-resilience-plan-2026-07-04.md`:

> flux controllers declare ~1–2c CPU limits each (~6c of limits total) vs ~1–11m actual. Trim limits to realistic values (e.g. 500m) so they don't distort scheduling/eviction math.

So: **not drift, and not a response to an incident** — a deliberate reservation-hygiene change. But the premise is wrong. CPU **limits** play no part in scheduling, and that task never touched **requests**, which are the only thing the scheduler reserves on. The ~6c of limits it removed were not distorting anything, and removing them freed exactly zero N-1 headroom. The companion review doc's own inventory shows it: `flux-system … req 0.45c … lim 6.00c` — the 0.45c was always the number that mattered.

Two more things went wrong in the execution:

- the plan's own text suggested **500m**; the commit shipped **100m**, equal to the request — 5× tighter than its own proposal, and the tightest value that still looks reasonable;
- the second acceptance box — *"Controllers stay Ready; reconciliation unaffected"* — was **never ticked**. It is still unchecked in the doc today. The regression was never measured.

Because the original reason does not survive contact with how limits actually work, and because requests are untouched here, reverting it costs the N-1 plan nothing.

## What it actually costs

| | stargate-command | equestria |
|---|---|---|
| Kustomizations in tree | 77 | **147** |
| kustomize-controller CPU limit | **100m** (== request) | 1 (upstream default) |
| Kustomization reconcile **p50** | 1.43s | **0.39s** |
| Kustomization reconcile **p95** | **103.7s** | **2.10s** |
| Max CFS throttle, 24h (kustomize-c) | **99.9%** | 59.8% |
| Liveness probe failures, 7d | **14** | **0** |

Half the workload, 50× the p95.

Throttling is not confined to bursts — the 14h series shows kustomize-controller sitting at 2–15% throttled at *idle*, on the periodic sweeps alone, and pinning 90–99% every time anything real happens. `helm-controller` (51% peak) and `source-controller` (54% peak) are caught by the same patch.

## The graceful exit was a symptom — this is a feedback loop

`exitCode: 0` / `reason: Completed` at 01:34:31Z is explained, and it raises the priority of the issue.

Ruled out first: the pod was never recreated (same pod, `startTime` 07-24, `restartCount` 3), so not an eviction, not a drain, not a rollout. Leader-election loss exits **1**, not 0.

What kubelet actually recorded:

```
prober_probe_total{pod=~"kustomize-controller.*", probe_type="Liveness", result="failed"}
  08-01 01:41 ·  08-01 01:51 ·  08-01 16:31 (x2) ·  08-01 16:51
  08-01 18:21 ·  08-02 00:11 ·  08-02 00:21 ·  08-02 01:41 (x3) ·  08-02 01:51
```

Every one of those timestamps lands on a throttle spike, and **no other pod in `flux-system` has a single liveness failure in 7 days** — only the one that is CPU-saturated.

The three in the `01:41` bucket cover the `01:34:31Z` kill. `livenessProbe` is `/healthz`, `timeoutSeconds: 1`, `failureThreshold: 3`; a container with a 10ms slice per 100ms CFS period cannot answer inside one second. Three misses in a row, kubelet SIGTERMs, controller-runtime shuts down cleanly → **exit 0, `Completed`**. Exactly the signature observed.

Then it closes:

> throttled → probe times out → SIGTERM → restart → re-reconcile all 77 Kustomizations → maximum throttling → probe times out

which is why the drain fired ~20 `FluxKustomizationProgressing` alerts and cascaded `dependency … is not ready` for 15+ minutes with nothing actually broken. The expensive part is not the slowness; it is that this is indistinguishable at a glance from a real Flux outage, and it gates real incident recovery on SGC behind an hours-long drain.

## The change

**Remove the CPU limit rather than raise it.** `cpu: null` in the strategic-merge patch deletes upstream's `1000m` instead of overriding it. A CFS quota throttles a bursty, latency-sensitive reconciler *even on a completely idle node* — which is the pathology here, and equestria still peaks at 59.8% throttle at `cpu: 1`. SGC's nodes are at 34–38% CPU (3950m allocatable each). Under contention, `cpu.shares` derived from the unchanged 100m request still keeps it well behind apiserver/kubelet.

Deliberately **not** touched:

- **Requests** stay 100m / 50m. Scheduling and the N-1 reservation math are untouched.
- **`--concurrent`** stays as-is: helm/source get 10, kustomize-controller gets 20 (Go's `flag` package takes the last occurrence — both patches append, the second wins). Both values are intentional and byte-identical to equestria, which runs 20 against 147 Kustomizations at p95 2.1s. They are now documented inline rather than left to be re-derived. The contradiction was 20 workers sharing 0.1 CPU; 20 workers on an uncapped 4-core node is not one, so no new one is created.
- **`memory: 1Gi`** stays for helm (148Mi peak) and source (84Mi peak).

**Raised** kustomize-controller memory to **2Gi**. Not opportunistic — directly coupled to this change. Its temp dir is `emptyDir: {medium: Memory}`, a tmpfs charged to the pod's memory cgroup, and the 436Mi peak was measured *while throttling serialised the workers*. With the cap gone, 20 in-memory builds genuinely run in parallel. kustomize-controller has no `OOMWatch` gate (only helm-controller does), so an OOM there is a crash-loop of the component that applies everything — worth the headroom.

`docs/sgc-n1-resilience-plan-2026-07-04.md` Task 2.2 is annotated **REVERSED — do not re-apply**, with the measurements, so the next reader of that plan doesn't restore the cap.

## Verification

Rendered locally against the real distribution artifact (`flux-operator build instance`, 2.9.3) and dry-run diffed server-side against live SGC. The entire substantive diff:

```
-            cpu: 100m      (x3 — kustomize, helm, source)
-            memory: 1Gi
+            memory: 2Gi    (kustomize-controller)
```

`notification-controller` is not targeted by the patch and is unchanged (idle at 2m, 0% throttled, 0 probe failures). Image-digest lines in the diff are an artifact of the local CLI not resolving digests — they appear identically when rendering the *unchanged* current instance, so they are not part of this change.

Also confirmed the `flux-system` `LimitRange` sets only `defaultRequest` (no `default`), so removing the limit genuinely leaves the container uncapped rather than having one silently reinjected.

**Not yet observed — predictions pending merge:**

- [ ] a no-op Kustomization reconcile finishing in seconds rather than minutes
- [ ] the tree draining in minutes across a controller restart

Both are measurable straight after rollout:

```bash
kubectl top pods -n flux-system
flux reconcile kustomization <a-no-op-ks> --with-source   # expect seconds
```

```promql
# p95, expect it to fall from ~103s toward equestria's ~2s
histogram_quantile(0.95, sum by (le) (rate(gotk_reconcile_duration_seconds_bucket{kind="Kustomization"}[1h])))

# should go to ~0
sum(rate(container_cpu_cfs_throttled_periods_total{namespace="flux-system"}[5m]))
  / sum(rate(container_cpu_cfs_periods_total{namespace="flux-system"}[5m]))

# should stop accruing
increase(prober_probe_total{namespace="flux-system",probe_type="Liveness",result="failed"}[7d])
```

## Failure mode and manual recovery

This edits the controller that applies edits, so the failure modes were considered before pushing:

- **Rollout restarts kustomize-controller.** Merging costs *one more* drain storm and one more burst of `Progressing` alerts. That is the known cost, and it should be the last one.
- **Bad render.** flux-operator fails the FluxInstance and leaves the existing Deployments running — fails safe at the current (working, if slow) config. `cpu: null` was chosen over a JSON-Patch `remove` op precisely because it is idempotent: `remove` errors if the key is ever absent, which would wedge rendering on a future upstream change. Both were built locally; both produce identical output today.
- **Bad rollout.** `replicas: 1` with default RollingUpdate keeps the old pod until the new one is Ready. Removing a limit cannot make a pod unschedulable — limits are not scheduled on.
- **If it goes wrong anyway:** `git revert` + `flux reconcile ks flux-system`. If Flux itself cannot apply, suspend the `flux-instance` HelmRelease and `kubectl -n flux-system set resources deploy/kustomize-controller --limits=cpu=1,memory=1Gi` by hand — the flux-operator-managed Deployments carry `kustomize.toolkit.fluxcd.io/ssa: Ignore`, so a manual edit will hold while suspended.

## Equestria

**Checked — no equestria change bundled, and none needed.** The two `values.yaml` files are byte-identical apart from the git URL and this one `cpu:` line: equestria's patch sets only `memory: 1Gi` and inherits upstream's `cpu: 1`. `.github/equestria-sync.yaml` syncs `flux-system/weave/` and `flux-system/capacitor/` but **not** `flux-system/flux-instance/`, which is exactly why the hand-edit on SGC never propagated and why equestria never picked up the cap.

Equestria does carry a milder version of the same trap, and it is worth naming: it peaks at **59.8%** CFS throttle at `cpu: 1`. It is nowhere near the cliff — p95 2.1s, zero probe failures, 147 Kustomizations — so there is no reason to touch it in this PR. If its tree keeps growing, the same argument for dropping the limit applies there; that is a separate change with its own evidence.

<!-- crew:agent=ralph -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
