### PR TITLE
fix(database): point barman-cloud at a Minio bucket that actually exists (vault#119)

### DIFF
--- a/kubernetes/apps/database/postgres/app/resources/values.yaml
+++ b/kubernetes/apps/database/postgres/app/resources/values.yaml
@@ -31,7 +31,17 @@ backups:
   provider: s3
   s3:
     region: "{{ .minio_region }}"
-    bucket: "{{ .backblaze_bucket }}"
+    # A Minio bucket, because the endpoint URL, access key and secret key
+    # around it are all Minio-on-truenas. What stood here until vault#119 was
+    # a templated reference to the backblaze item's bucket field, which names
+    # a bucket that exists only on Backblaze B2 -- so every WAL archive died
+    # with NoSuchBucket, reported as barman's opaque "exit status 4". Do not
+    # reintroduce a backblaze-prefixed reference here: the two 1Password items
+    # this file is templated from are told apart only by that prefix, and
+    # nothing downstream will catch the mismatch. The bucket is provisioned in
+    # home-operations stacks/home and must exist before this reconciles,
+    # because barman-cloud does not create buckets.
+    bucket: "cnpg-${CLUSTER_CNAME}"
     # Dedicated prefix so barman's base backups + WAL never share a namespace
     # with the logical dumps or the `-restore` staging bucket.
     path: "/barman/${CLUSTER_CNAME}"


### PR DESCRIPTION
## Why

`vault#119`. WAL archiving has failed on every instance since #1738 landed at 00:17Z:

```
ContinuousArchiving=False
unexpected failure invoking barman-cloud-wal-archive: exit status 4
```

Exit 4 is barman's `GeneralErrorExit` (`src/barman/clients/cloud_cli.py`) — the catch-all for an unhandled exception, deliberately generic. The plugin sidecar log has the real error:

```
Barman cloud WAL archiver exception: An error occurred (NoSuchBucket)
when calling the PutObject operation: The specified bucket does not exist
```

`s3://stargate-command-db` does not exist. `mc ls` against truenas Minio returns exactly two buckets: `home-operations` and `thanos*`. `stargate-command-db` is a **Backblaze B2** bucket name, sourced from the `${BACKBLAZE_DATABASE}` 1Password item, and #1738 paired it with the Minio endpoint and Minio credentials. The endpoint and the credentials were right; the bucket name came from the wrong secret. That was my error in #1738.

## What this actually costs us right now

- **Nothing has ever been archived.** `pg_stat_archiver` on postgres-3 (the primary) has `last_archived_time` frozen at `2026-08-02 00:26:17Z` and `failed_count` climbing. The segments it counts as archived were CNPG's no-op archiver running with no object store attached — they went nowhere. **PITR does not exist on this cluster.**
- **pg_wal cannot recycle.** 64 `.ready` files queued on postgres-3, accumulating at ~26 segments/hour (~410 MB/h). 36G free on a 40G PVC ≈ **3.5–4 days**. SGC is the binding constraint across both clusters, and it has just spent the `wal_keep_size=1GB` cushion that was hiding the growth (64 ready ≈ 1.02G ≈ the whole recycle pool), so `pg_wal` starts genuinely climbing here first. This cluster has already lost authentik once to this shape of problem in 2026-07.

## What changed

**One file, one value:** `bucket: "cnpg-${CLUSTER_CNAME}"`, plus a comment saying why. The new name is explicit about which object store it lives in and stops the WAL destination from silently moving if the B2 item is ever rotated.

The `Cluster` spec is untouched — this only changes `ObjectStore.spec.configuration.destinationPath`, so no rolling restart of the instances.

### Two corrections since the first push

- **Rebased onto `origin/main`.** The branch was cut from a local `main` carrying sgc#1742 (tsiam), so this PR was showing that PR's files too. Rebuilt from `origin/main`; the Files tab is now one file.
- **Comment rewritten in prose.** My first version quoted the old value literally, two braces and all. CI here did not catch it, because **this repo does not have `scripts/eso-values-lint` yet** — equestria's copy did catch it on the sibling PR. I ran equestria's linter against this tree to verify: my file is clean. It does report one pre-existing finding at `kubernetes/apps/longhorn-system/longhorn/values.yaml:4` (a commented-out `backupTarget` with a live `${...}` substitution). Out of scope here, flagged separately — and one more argument for syncing the linter into this repo.

## Ordering — do not merge this first

barman-cloud does not create buckets. Blocked on **david-driscoll/home-operations#630**, which provisions `cnpg-sgc` and must be **applied**, not merely merged. That PR is now also clean — one file, `stacks/home/index.ts`.

## Second condition, and why it is not a second bug

```
LastBackupSucceeded=False  requested plugin is not available: barman-cloud.cloudnative-pg.io
```

This is stale, not live. The chart's ScheduledBackup is created with `immediate: true`; it fired at 00:27Z, in the window between the ObjectStore being created and the instance pods being recreated with the barman sidecar injected. The backup hit instances that genuinely had no such plugin. It has not been retried since — `nextScheduleTime` is 16:00Z.

The plugin is registered now and the sidecars are actively invoking barman — that is what produces the exit-4 errors. Once a bucket exists, an on-demand `Backup` will clear it. **Acceptance is a completed backup, not the plugin merely loading** — I will verify and report on vault#119.

## Worth noting: SGC's controllers are the healthy ones

equestria's `postgres-operator` has 12 restarts and its `plugin-barman-cloud` 3; SGC has 0 and 0, with the identical archiving symptom. That difference is not about barman. equestria's operator is dying on `leader election lost` — `Error retrieving lease lock ... context deadline exceeded` reaching the apiserver — and those crashes predate the archiving change. Equestria control-plane reachability, unrelated to this PR, flagged separately on vault#119.

## Not fixed here, deliberately

The `recovery:` block still pairs the backblaze bucket field with the Minio endpoint — the same class of bug. It is inert under `mode: standalone`, but it is the block you flip to during an actual restore, so it needs the same correction *and* a rehearsal before anyone calls PITR real. Tracked on vault#119.

<!-- crew:agent=seraph -->