### PR TITLE
docs(volsync): document the components/volsync <-> volsync-restore coupling (vault#120)

### DIFF
--- a/kubernetes/components/volsync/AGENTS.md
+++ b/kubernetes/components/volsync/AGENTS.md
@@ -2,3 +2,55 @@
 
 - This is the volsync component
 - It's presence as part of a ks.yaml file will add these resources into a given component.
+- It provides the **steady-state backup path only**: the `ExternalSecret` holding the restic
+  repository credential, the nightly `ReplicationSource`, and the app's `PersistentVolumeClaim`.
+
+## Who consumes this
+
+Apps opt in by naming this component in their own `ks.yaml` `components:` list, as a path
+relative to that file (e.g. `../../../components/volsync`). Those are ordinary files in this
+repo, so `git grep -n 'components/volsync$' -- '**/ks.yaml'` lists every consumer — the `$`
+anchor matters, or the results also sweep in `components/volsync-restore`.
+
+## Coupling with `components/volsync-restore`
+
+`pvc.yaml` declares `spec.dataSourceRef` -> `ReplicationDestination/${APP}-dst`, which is
+supplied by the sibling `components/volsync-restore` component and **not** by this one. That is
+deliberate:
+
+- `dataSourceRef` is only consulted when the PVC is first **created**. Once the PVC is `Bound`
+  the field is immutable and inert, so the `ReplicationDestination` it names does not have to
+  exist for the life of the app. Every volsync app in the estate runs this way today.
+- A **brand-new** PVC is the opposite case, and this is the trap. The VolSync volume populator
+  claims it, Longhorn stands down (`assuming an external populator will provision the volume`),
+  and the populator then waits forever for a `ReplicationDestination` that nothing creates — so
+  the PVC never binds and the pod never schedules. Symptom: PVC `Pending`, no Longhorn volume,
+  no obvious error. See equestria-cluster#2987 and stargate-command-cluster#1739.
+- So on any **first** deploy of an app — whether or not a backup exists to restore from — add
+  `components/volsync-restore` to the app's `ks.yaml` `components:` list, let the restore run
+  (with no snapshots it is a successful no-op that initializes the repo and binds an empty
+  volume), then **remove it again**.
+
+Do not try to fix a stuck PVC by editing `pvc.yaml`: `dataSourceRef` is immutable, and the
+populator re-enqueues unbound PVCs, so creating the `ReplicationDestination` is sufficient. Note
+also that `kustomization.yaml` stamps `kustomize.toolkit.fluxcd.io/force: enabled` on everything
+here — changing an immutable PVC field (`storageClassName`, `dataSourceRef`) makes Flux delete
+and recreate the PVC, which destroys the data. Expanding `VOLSYNC_CAPACITY` is safe; changing
+storage class is not.
+
+Leaving the `ReplicationDestination` bundled into this component is what caused the **2026-07
+Longhorn storage incident**: a `restore-once` trigger that had already fired kept a fully
+replicated `${APP}-dst-dest`/`${APP}-dst-cache` PVC pair on disk indefinitely, and the nightly
+`volsync-restore-cleanup` CronJob (`30 3 * * *`) reaping them fought Flux recreating them on the
+next reconcile — re-running a real restic restore every day. This repo split the component in
+2026-07 as part of that incident response; home-operations carried the bundled shape until
+vault#120.
+
+## Substitutions worth pinning in the app's `ks.yaml`
+
+- `VOLSYNC_CAPACITY` — the app PVC size. Always set it.
+- `VOLSYNC_CACHE_CAPACITY` — the restic metadata cache. The defaults are **asymmetric**
+  (`ReplicationSource` 2Gi, `ReplicationDestination` 8Gi), so pin it explicitly rather than
+  inheriting an 8Gi `longhorn-cache` volume by accident during a restore.
+- `VOLSYNC_PUID` / `VOLSYNC_PGID` — must match the app's runtime user or the mover writes files
+  the app cannot read.


### PR DESCRIPTION
Backports the rewritten `kubernetes/components/volsync/AGENTS.md` from
home-operations (PR david-driscoll/home-operations#631, vault#120).

## Why

vault#120 fixed home-operations' volsync component, which still bundled
`replicationdestination.yaml` after the 2026-07 Longhorn storage incident. Part of
that work rewrote the component's `AGENTS.md` from a 3-line stub into real
documentation.

This repo split `volsync-restore` out back in 2026-07 during the incident response,
but its `components/volsync/AGENTS.md` was never updated — it is still the same
3-line stub, and only `components/volsync-restore/AGENTS.md` explains the incident.
So the documentation gap that produced equestria-cluster#2987 and
stargate-command-cluster#1739 still exists here.

## What the doc now covers

- What the component provides: the **steady-state backup path only** (ExternalSecret,
  nightly ReplicationSource, app PVC).
- The coupling with `components/volsync-restore` — `pvc.yaml` declares
  `dataSourceRef` -> `ReplicationDestination/${APP}-dst`, which this component does
  **not** supply.
- Both directions of that behaviour: inert once the PVC is `Bound`, but a brand-new
  PVC never binds without the RD — the VolSync volume populator claims it, Longhorn
  stands down, and the PVC sits `Pending` with no obvious error.
- The obligation to remove `volsync-restore` once the restore completes, and why: the
  2026-07 incident, where the `volsync-restore-cleanup` CronJob (`30 3 * * *`) reaping
  the leftover PVC pair fought Flux recreating it on the next reconcile.
- The asymmetric `VOLSYNC_CACHE_CAPACITY` defaults (ReplicationSource 2Gi,
  ReplicationDestination 8Gi) — pin it explicitly.
- The `kustomize.toolkit.fluxcd.io/force: enabled` hazard: changing an immutable PVC
  field makes Flux delete and recreate the PVC, destroying the data.

## Adapted for this repo

Text is otherwise verbatim from the home-operations copy. Two sections are
repo-specific and were rewritten:

1. **"Who consumes this"** — the home-operations copy explains that its components are
   referenced from the cluster repos via `sourceRef: GitRepository/home-operations` and
   are invisible to a local `git grep`. That does not apply here, where components are
   referenced by ordinary `ks.yaml` files in this repo. Replaced with the local
   `git grep` invocation (anchored, so it doesn't also match `volsync-restore`),
   verified against this repo.
2. **Provenance sentence** — home-operations says "The cluster repos split the
   component in 2026-07; this repo carried the bundled shape until vault#120", which is
   backwards from inside a cluster repo. Reversed to match.

## Verification

- Facts re-checked against this repo rather than copied on faith: `pvc.yaml`
  `dataSourceRef` target, the `force: enabled` label in `kustomization.yaml`, the 2Gi /
  8Gi `VOLSYNC_CACHE_CAPACITY` split between `replicationsource.yaml` and
  `volsync-restore/replicationdestination.yaml`, the `30 3 * * *` cleanup CronJob
  schedule, and the 2026-07-18 split commit.
- `hk check --all` passes.
- Docs only — no manifest changes, so `flate` / flux-local output is unaffected.

<!-- crew:agent=seraph -->
