### PR TITLE
fix(longhorn): escape the commented backupTarget so envsubst leaves it alone

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn/values.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/values.yaml
@@ -1,7 +1,12 @@
 ---
 
+# The dollars below are DOUBLED, which is the escape. configMapGenerator
+# slurps this file whole and Flux postBuild envsubst then runs over the built
+# output, comments included -- unescaped, this commented-out example put the
+# real Spike IP and cluster name into the deployed ConfigMap. Halve them again
+# when uncommenting.
 # defaultBackupStore:
-#   backupTarget: nfs://${SPIKE_IP}:/mnt/stash/backup/${CLUSTER_CNAME}/longhorn
+#   backupTarget: nfs://$${SPIKE_IP}:/mnt/stash/backup/$${CLUSTER_CNAME}/longhorn
   # backupTargetCredentialSecret: s3-secret
 preUpgradeChecker:
   upgradeVersionCheck: false


### PR DESCRIPTION
## What

`kubernetes/apps/longhorn-system/longhorn/values.yaml` lines 3-4 used single
dollars in the commented-out `defaultBackupStore` example:

```yaml
# defaultBackupStore:
#   backupTarget: nfs://${SPIKE_IP}:/mnt/stash/backup/${CLUSTER_CNAME}/longhorn
```

The file is slurped whole by a kustomize `configMapGenerator` into
`longhorn-config`, and Flux `postBuild` envsubst then runs over the built
output **including comments**. So being commented out bought nothing — the real
Spike IP and the cluster name were substituted into the deployed ConfigMap.

Confirmed on the live cluster before this change: the `longhorn-config`
ConfigMap in `longhorn-system` on SGC contained the real Spike IP and `sgc` on
that commented line.

## Fix

Double the dollars (`$${SPIKE_IP}`) — the documented Flux escape — and carry
the same explanatory comment `equestria-cluster` already has, so the two
clusters match byte for byte in this header.

## Verification

- `kustomize build` on the app dir renders `$${SPIKE_IP}` / `$${CLUSTER_CNAME}`
  into the ConfigMap, i.e. the escape survives generation intact.
- equestria-cluster has been running this exact form for a while; its live
  `longhorn-config` ConfigMap shows the literal `${SPIKE_IP}` and
  `${CLUSTER_CNAME}` — the `$$` collapses to a single `$` and no substitution
  happens. That's the end-to-end proof the escape does what it claims.
- Post-merge, SGC's ConfigMap should show the same literal placeholders instead
  of the real values.

Comment-only change to a commented-out block; no Longhorn behaviour changes.
`defaultBackupStore` stays disabled, and the comment notes to halve the dollars
again if anyone uncomments it.

<!-- crew:agent=seraph -->
