### PR TITLE
feat(external-secrets): ClusterSecretStore/openbao for SGC

### DIFF
--- a/kubernetes/apps/kube-system/external-secrets/stores/kustomization.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./onepassword-store.yaml
   - ./kubernetes.yaml
+  - ./openbao-store.yaml

--- a/kubernetes/apps/kube-system/external-secrets/stores/openbao-store.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/openbao-store.yaml
@@ -1,0 +1,74 @@
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/rbac.authorization.k8s.io/clusterrolebinding_v1.json
+#
+# ---- WHY external-secrets NEEDS system:auth-delegator IN THIS CLUSTER -------
+#
+# OpenBao runs in equestria and validates a login by calling TokenReview
+# against THIS cluster's API server. The usual cross-cluster recipe hands
+# OpenBao a long-lived `token_reviewer_jwt` — a permanent ServiceAccount token
+# stored inside the auth mount — which is a standing credential in exactly the
+# place the OpenBao migration is trying to stop keeping them.
+#
+# The `kubernetes-sgc` mount deliberately has NO reviewer JWT (see
+# home-operations components/openbao/clusterAuth.ts). OpenBao instead performs
+# the TokenReview using the CLIENT's own token — the one external-secrets
+# presents at login — which only works if that ServiceAccount may create
+# TokenReviews. That is what `system:auth-delegator` grants, and it is the
+# whole of the privilege: it does not read secrets and it does not confer any
+# access in this cluster beyond asking "is this token valid?".
+#
+# Delete this binding and every SGC ExternalSecret fails at LOGIN with
+# "permission denied" from the TokenReview call — not at read, and not in a way
+# that names this binding. It is load-bearing.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-secrets-openbao-token-review
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: kube-system
+---
+# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/external-secrets.io/clustersecretstore_v1.json
+#
+# Phase 7: SGC reads from the ONE OpenBao, which runs in equestria.
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: openbao
+spec:
+  provider:
+    vault:
+      # The public ingress hostname, NOT a Service — this cluster has no route
+      # to equestria's ClusterIPs. equestria's own store points at
+      # `openbao-active` to skip a hop; that is unavailable from here and is an
+      # optimisation rather than a requirement, because standbys FORWARD client
+      # requests to the active node over port 8201 rather than redirecting.
+      # (Verified: every OpenBao API call made while building this phase went
+      # through this same hostname and none saw a redirect. Note `/v1/sys/health`
+      # answers 429 through it, which is the documented "unsealed and standby"
+      # code and is healthy — do not read it as rate limiting.)
+      server: https://bao.equestria.driscoll.tech
+      # The kv-v2 mount holding real secrets.
+      path: secrets
+      version: v2
+      auth:
+        kubernetes:
+          # A SECOND mount, not the `kubernetes` one equestria uses. That mount
+          # is configured with kubernetes_host=https://kubernetes.default.svc:443,
+          # which resolves to equestria's OWN API server, so it can only validate
+          # equestria ServiceAccount tokens. Pointing this store at it fails at
+          # login with "service account name not authorized" — which reads like a
+          # role misconfiguration rather than a wrong cluster.
+          mountPath: kubernetes-sgc
+          # Bound in OpenBao to exactly this ServiceAccount + namespace, and
+          # carries the `eso-sgc` policy: read on secrets/shared/* and
+          # secrets/clusters/sgc/*. Nothing wider.
+          role: eso-sgc
+          serviceAccountRef:
+            name: external-secrets
+            namespace: kube-system


### PR DESCRIPTION
Phase 7’s gate. SGC reads from the ONE OpenBao, which runs in equestria. **No ExternalSecret is repointed here** — this only makes the store available.

### Two resources, and the RBAC one is load-bearing

OpenBao validates a login by calling TokenReview against *this* cluster’s API server. The usual cross-cluster recipe hands it a long-lived `token_reviewer_jwt` — a permanent ServiceAccount token stored inside the auth mount, which is a standing credential in exactly the place this migration is trying to stop keeping them.

The `kubernetes-sgc` mount deliberately has none. OpenBao performs the TokenReview using the **client’s own token** instead, which only works if `external-secrets` may create TokenReviews — hence the `system:auth-delegator` binding. That is the whole of the privilege: it reads no secrets and confers no access here beyond asking *"is this token valid?"*.

**Delete that binding and every SGC ExternalSecret fails at LOGIN** with `permission denied` from the TokenReview call — not at read, and not in a way that names the binding. It is commented in-file accordingly.

### Two details that would otherwise bite

- **The ingress hostname, not a Service.** This cluster has no route to equestria’s ClusterIPs. equestria’s store points at `openbao-active` to skip a hop; that is unavailable from here and is an optimisation, not a requirement — standbys *forward* to the active node over 8201 rather than redirecting. Every OpenBao call made while building this phase went through this hostname and none saw a redirect. (`/v1/sys/health` answers **429** there, which is the documented "unsealed and standby" code — healthy, not rate limiting.)
- **`mountPath: kubernetes-sgc`, not `kubernetes`.** That mount is configured with `kubernetes_host = https://kubernetes.default.svc:443` — equestria’s own API server — so it can only validate equestria ServiceAccount tokens. Pointing this store at it fails at login with `service account name not authorized`, which reads like a role misconfiguration rather than a wrong cluster.

### Already live on the OpenBao side

Verified after vault#170’s root ceremony and home-operations#711’s apply:

```
mount   kubernetes-sgc   type=kubernetes
config  kubernetes_host=https://10.10.209.201:6443  disable_local_ca_jwt=true  has_ca=true  has_reviewer=false
role    eso-sgc  ->  kube-system/external-secrets   policies=[eso-sgc]  ttl=3600
```

`flate` 182 passed.

**After merge:** `kubectl get clustersecretstore openbao` should report `Valid` — that is the first real proof the cross-cluster login works, since the store validates by authenticating.

<!-- crew:agent=claude -->