### PR TITLE
feat(external-secrets): move SGC's two shared components onto OpenBao

### DIFF
--- a/kubernetes/components/alerts/github-status/externalsecret.yaml
+++ b/kubernetes/components/alerts/github-status/externalsecret.yaml
@@ -7,7 +7,14 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    # Phase 7: one edit here moves 14 ExternalSecrets, one per namespace.
+    # Verified first — all three template fields exist in OpenBao under the
+    # same names (the [\W]->_ rewrite is a no-op on them, they are already
+    # snake_case), and none is empty.
+    #
+    # Unlike equestria, this component has no twin: SGC does not source
+    # anything from home-operations, so this file is the only copy.
+    name: openbao
   target:
     name: github-status-token-secret
     template:
@@ -17,7 +24,9 @@ spec:
         githubAppPrivateKey: "{{ .github_app_private_key }}"
   dataFrom:
     - extract:
-        key: Github Actions Runner (david-driscoll)
+        # was: Github Actions Runner (david-driscoll)
+        # Path within the `secrets` mount; the store pins `path: secrets`.
+        key: shared/github-actions-runner-david-driscoll
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/components/volsync/externalsecret.yaml
+++ b/kubernetes/components/volsync/externalsecret.yaml
@@ -6,9 +6,17 @@ metadata:
   name: "${APP}-volsync"
 spec:
   refreshInterval: 4m
+  # Phase 7: one edit here moves 9 ExternalSecrets across 4 namespaces — every
+  # VolSync restic repository in this cluster. Verified before the change: the
+  # template reads exactly one field (.credential; RESTIC_REPOSITORY is a
+  # literal), secrets/shared/volsync-password has it and it is not empty.
+  #
+  # No rewrite rules here, so the "empty is not missing" trap cannot apply —
+  # that needs a template reference to a field absent in OpenBao, and the one
+  # field referenced is present.
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: "${APP}-volsync-secret"
     template:
@@ -23,4 +31,6 @@ spec:
         RESTIC_PASSWORD: "{{ .credential }}"
   dataFrom:
     - extract:
-        key: 'Volsync Password'
+        # was: 'Volsync Password'   (1Password item title in vault Eris)
+        # Path within the `secrets` mount; the store pins `path: secrets`.
+        key: shared/volsync-password


### PR DESCRIPTION
Phase 7. **Two files, 23 of SGC’s 34 ExternalSecrets.**

| Component | Moves | Files |
|---|---|---|
| `github-status-token` | 14 namespaces | 1 |
| `*-volsync` | 9 across 4 namespaces — every restic repository here | 1 |

### Verified against the live server, not against `mapping.yaml`

- `shared/github-actions-runner-david-driscoll` carries all three template fields under identical names, so the `[\W]->_` rewrite is a **no-op** on them. Kept anyway: removing it would change nothing and risk something.
- `shared/volsync-password` carries `credential`, the single field the volsync template reads (`RESTIC_REPOSITORY` is a literal).
- **Neither path has an empty-valued field**, so the "empty is not missing" trap that broke kometa in Phase 6 cannot apply.

### The Phase 6 two-repo trap does not exist here

equestria’s copies of these components have twins in `home-operations`, and 16 equestria Kustomizations source from *that* copy — which is what left `dynacat` behind on 1Password with a Kustomization reporting perfectly healthy. SGC sources nothing from home-operations, so each file here is the only copy and one edit is the whole change.

`flate` 182 passed. Every rewritten key asserted to start with a mount prefix rather than pattern-matched for "looks unmigrated".

**After merge:** all 23 should report `SecretSynced`, and `kubectl get es -A` should drop from 34 on `onepassword-connect` to 11.

<!-- crew:agent=claude -->