### PR TITLE
feat(external-secrets): move SGC's remaining app secrets onto OpenBao

### DIFF
--- a/kubernetes/apps/database/postgres/backups/externalsecret.yaml
+++ b/kubernetes/apps/database/postgres/backups/externalsecret.yaml
@@ -9,7 +9,7 @@ spec:
   refreshInterval: 4m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: postgres-backups
     creationPolicy: Owner
@@ -25,7 +25,7 @@ spec:
         CONNECT_TOKEN: "{{ .credential }}"
   dataFrom:
     - extract:
-        key: "Eris 1Password Connect Access Token"
+        key: shared/eris-1password-connect-access-token
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/kube-system/etcd/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/etcd/externalsecret.yaml
@@ -7,12 +7,12 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: talos-etcd-restic-keys
     creationPolicy: Owner
   data:
     - secretKey: RESTIC_PASSWORD
       remoteRef:
-        key: Volsync Password
+        key: shared/volsync-password
         property: credential

--- a/kubernetes/apps/kube-system/headlamp/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/headlamp/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -27,7 +27,7 @@ spec:
         OIDC_SCOPES: "openid profile email"
   dataFrom:
     - extract:
-        key: '${CLUSTER_CNAME}-${APP}-oidc-credentials'
+        key: clusters/${CLUSTER_CNAME}/apps/${APP}/oidc
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/kube-system/registry/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/registry/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 1m
   target:
@@ -33,7 +33,7 @@ spec:
             templateAs: Values
   dataFrom:
     - extract:
-        key: 'Docker Hub'
+        key: shared/docker-hub
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/kube-system/secrets/docker-hub-auth/docker-hub-auth.yaml
+++ b/kubernetes/apps/kube-system/secrets/docker-hub-auth/docker-hub-auth.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -37,7 +37,7 @@ spec:
           }
   dataFrom:
     - extract:
-        key: 'Docker Hub'
+        key: shared/docker-hub
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/observability/prometheus-proxy/externalsecret.yaml
+++ b/kubernetes/apps/observability/prometheus-proxy/externalsecret.yaml
@@ -10,7 +10,7 @@ spec:
   refreshInterval: 4m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: *name
     creationPolicy: Owner
@@ -28,7 +28,7 @@ spec:
               - alertmanager-svc.observability.svc.cluster.local:9093
   dataFrom:
     - extract:
-        key: "Thanos S3 Storage"
+        key: shared/thanos-s3-storage
       rewrite:
         - regexp:
             source: "[\\W]"

--- a/kubernetes/apps/sgc/dns/technitium/externalsecret.yaml
+++ b/kubernetes/apps/sgc/dns/technitium/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   refreshPolicy: Periodic
   refreshInterval: 4m
   target:
@@ -23,17 +23,17 @@ spec:
   data:
     - secretKey: DNS_SERVER_ADMIN_PASSWORD
       remoteRef:
-        key: "Technitium Password"
+        key: shared/technitium-password
         property: password
     - secretKey: DNS_SERVER_SSO_AUTHORITY
       remoteRef:
-        key: "sgc-technitium-oidc-credentials"
+        key: clusters/sgc/apps/technitium/oidc
         property: issuer
     - secretKey: DNS_SERVER_SSO_CLIENT_ID
       remoteRef:
-        key: "sgc-technitium-oidc-credentials"
+        key: clusters/sgc/apps/technitium/oidc
         property: client_id
     - secretKey: DNS_SERVER_SSO_CLIENT_SECRET
       remoteRef:
-        key: "sgc-technitium-oidc-credentials"
+        key: clusters/sgc/apps/technitium/oidc
         property: client_secret

--- a/kubernetes/apps/sgc/home/home-assistant/externalsecret.yaml
+++ b/kubernetes/apps/sgc/home/home-assistant/externalsecret.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     template:
       metadata:
@@ -20,14 +20,24 @@ spec:
         id_rsa.pub: "{{ .publickey }}"
         authorized_keys: "{{ .publickey }}"
         ssh: "{{ .privatekey }}"
-        known_hosts: "{{ .known_hosts }}"
+        # NOT `.known_hosts`. OpenBao stores this field as "known hosts" —
+        # with a SPACE — and the Vault provider returns key names verbatim.
+        # This template only ever worked because the ESO 1Password provider
+        # silently sanitised spaces to underscores in `extract` keys; on
+        # OpenBao `{{ .known_hosts }}` renders nothing and, under
+        # missingkey=error, fails the WHOLE ExternalSecret.
+        #
+        # `.knownhosts` comes from the explicit `data:` mapping below, which
+        # names the property itself and so is provider-independent. Same for
+        # .privatekey / .publickey above — that is why they were never at risk.
+        known_hosts: "{{ .knownhosts }}"
   dataFrom:
     - extract:
-        key: 'Eris SSH Key'
+        key: shared/eris-ssh-key
   data:
     - secretKey: publickey
       remoteRef:
-        key: &ssh-key 'Eris SSH Key'
+        key: &ssh-key shared/eris-ssh-key
         property: public key
     - secretKey: privatekey
       remoteRef:

--- a/kubernetes/apps/sgc/idp/authentik/externalsecret.yaml
+++ b/kubernetes/apps/sgc/idp/authentik/externalsecret.yaml
@@ -11,7 +11,7 @@ spec:
   refreshInterval: 4m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: ${APP}
     creationPolicy: Owner
@@ -41,7 +41,7 @@ spec:
         AUTHENTIK_POSTGRESQL__CONN_HEALTH_CHECKS: "true"
   dataFrom:
     - extract:
-        key: 'Authentik Secret Key'
+        key: shared/authentik-secret-key
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
@@ -55,7 +55,7 @@ spec:
   refreshInterval: 4m
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-connect
+    name: openbao
   target:
     name: ${APP}-bootstrap
     creationPolicy: Owner
@@ -72,13 +72,13 @@ spec:
         AUTHENTIK_BOOTSTRAP_EMAIL: "{{ .user_username }}"
   dataFrom:
     - extract:
-        key: 'Authentik Token'
+        key: shared/authentik-token
       rewrite:
         - regexp:
             source: "(.*)"
             target: "token_$1"
     - extract:
-        key: 'Authentik Admin'
+        key: shared/authentik-admin
       rewrite:
         - regexp:
             source: "(.*)"


### PR DESCRIPTION
Phase 7 — the 10 ExternalSecrets left after the two components (#1794). Verified per path against the live server; **none of the referenced fields is empty in OpenBao**, so the "empty is not missing" trap cannot apply.

| ExternalSecret | OpenBao path |
|---|---|
| `postgres-backups` | `shared/eris-1password-connect-access-token` |
| `docker-hub-auth`, `registry-values` | `shared/docker-hub` |
| `talos-etcd-restic-keys` | `shared/volsync-password` |
| `technitium-env` | `shared/technitium-password` + `clusters/sgc/apps/technitium/oidc` |
| `thanos-ruler-alertmanager-config` | `shared/thanos-s3-storage` |
| `authentik` | `shared/authentik-secret-key` |
| `authentik-bootstrap` | `shared/authentik-token`, `shared/authentik-admin` |
| `headlamp-oidc` | `clusters/${CLUSTER_CNAME}/apps/${APP}/oidc` |
| `home-assistant-ssh` | `shared/eris-ssh-key` |

### A new trap, and it would have broken `home-assistant-ssh`

Its template read `{{ .known_hosts }}`. OpenBao stores that field as `known hosts` — **with a space** — and the Vault provider returns key names verbatim. It only ever worked because the ESO **1Password provider** silently sanitises spaces to underscores in `extract` keys. On OpenBao the reference renders nothing and, under `missingkey=error`, **fails the whole ExternalSecret**.

Different layer from the Phase 6 finding (that was the 1Password *Operator* sanitising Secret keys). The fix is deliberately **not** a rewrite: the manifest already carries an explicit `data:` mapping naming the property (`knownhosts <- known hosts`), so the template now reads `.knownhosts` and depends on no provider’s key mangling. `.privatekey`/`.publickey` come from the same mapping, which is why they were never at risk.

Also caught in review: that file addresses the item through a YAML anchor (`&ssh-key`), so the literal title survived the first pass in three `data:` entries even though the `dataFrom` had already been rewritten.

### The substituted key

`headlamp-oidc` keeps a substituted key — the shape that broke dynacat — but it now resolves **inside the mount**: `CLUSTER_CNAME=sgc` and `APP=headlamp` give `clusters/sgc/apps/headlamp/oidc`, which exists with 9 fields. Asserted rather than assumed: every rewritten key in this PR was checked to start with `shared/` or `clusters/`.

The three Backblaze-blocked ExternalSecrets are **deliberately untouched** and keep their 1Password store — they need the TrueNAS Minio switch first.

`flate` 182 passed.

**After merge:** SGC should be down to 3 on `onepassword-connect` (the Backblaze three), with the 13 `OnePasswordItem` CRs still to convert.

<!-- crew:agent=claude -->