### PR TITLE
feat(external-secrets): SGC's OnePasswordItem CRs become ExternalSecrets

### DIFF
--- a/kubernetes/apps/cert-manager/cert-issuers/secret.yaml
+++ b/kubernetes/apps/cert-manager/cert-issuers/secret.yaml
@@ -1,10 +1,38 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+#
+# THE KEY IS NO LONGER A SUBSTITUTION. Carrying a variable across would hide
+# whether the value is a 1Password item path or an OpenBao path — the shape that
+# broke dynacat. The path is spelled out so it is visibly inside the `secrets`
+# mount. An identical copy lives at kubernetes/apps/network/secrets/cloudflare-default-domain.yaml.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: cloudflare-default-domain
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: cloudflare-default-domain
 spec:
-    itemPath: "${CLOUDFLARE_SECRET}"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: cloudflare-default-domain
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: CLOUDFLARE_SECRET -> vaults/Eris/items/7ntcze3fqqzun7huc7vyoirco4 ("Cloudflare (driscoll.tech)")
+        key: shared/cloudflare-driscoll-tech

--- a/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/ks.yaml
@@ -33,8 +33,10 @@ spec:
       kind: HelmRelease
       name: *app
       namespace: *namespace
-    - apiVersion: onepassword.com/v1
-      kind: OnePasswordItem
+    # Phase 7: the tunnel token is an ExternalSecret against
+    # ClusterSecretStore/openbao now, not a OnePasswordItem CR.
+    - apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
       name: cloudflare-tunnel
       namespace: *namespace
   postBuild:

--- a/kubernetes/apps/network/cloudflare-tunnel/secret.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/secret.yaml
@@ -1,10 +1,37 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+#
+# This is SGC's OWN tunnel token, distinct from the one in the `sgc` namespace
+# which is equestria's. ./ks.yaml healthChecks this resource by kind — that
+# reference changed with it.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: cloudflare-tunnel
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: cloudflare-tunnel
 spec:
-    itemPath: "${CLOUDFLARE_TUNNEL_SECRET}"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: cloudflare-tunnel
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: CLOUDFLARE_TUNNEL_SECRET -> vaults/Eris/items/inxq5pxexz7jhhun5ifa5pbjhi ("Stargate Command Cloudflare Tunnel")
+        key: shared/stargate-command-cloudflare-tunnel

--- a/kubernetes/apps/network/external-dns/technitium/secret.yaml
+++ b/kubernetes/apps/network/external-dns/technitium/secret.yaml
@@ -1,10 +1,33 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: technitium-tsig-key
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: technitium-tsig-key
 spec:
-    itemPath: vaults/Eris/items/g32sc45j6dj2qkjqtgikjmaude
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: technitium-tsig-key
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/g32sc45j6dj2qkjqtgikjmaude
+        key: shared/technitium-tsig-key

--- a/kubernetes/apps/network/external-dns/unifi/secret.yaml
+++ b/kubernetes/apps/network/external-dns/unifi/secret.yaml
@@ -1,10 +1,43 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+#
+# THE REWRITE IS LOAD-BEARING. A field name here contains a space, which is not
+# a legal Kubernetes Secret key, so without it the API server rejects the whole
+# Secret. The 1Password Operator sanitised the same way, which is why the live
+# Secret already reads with dashes — this reproduces it exactly rather than
+# approximating it with the repo's usual [\W] -> _ rule.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: unifi-dns-secret
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: unifi-dns-secret
 spec:
-    itemPath: "vaults/Eris/items/nxhctyryy6b7hauxfysmzev6uu"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: unifi-dns-secret
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/nxhctyryy6b7hauxfysmzev6uu ("Unifi Api Key Eris Cluster")
+        key: shared/unifi-api-key-eris-cluster
+      rewrite:
+        - regexp:
+            source: "[^-._a-zA-Z0-9]"
+            target: "-"

--- a/kubernetes/apps/network/secrets/cloudflare-default-domain.yaml
+++ b/kubernetes/apps/network/secrets/cloudflare-default-domain.yaml
@@ -1,10 +1,36 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+#
+# Twin of kubernetes/apps/cert-manager/cert-issuers/secret.yaml; both must
+# change together. See that file for why the substitution was not carried over.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: cloudflare-default-domain
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: cloudflare-default-domain
 spec:
-    itemPath: "${CLOUDFLARE_SECRET}"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: cloudflare-default-domain
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: CLOUDFLARE_SECRET -> vaults/Eris/items/7ntcze3fqqzun7huc7vyoirco4
+        key: shared/cloudflare-driscoll-tech

--- a/kubernetes/apps/network/secrets/home-assistant.yaml
+++ b/kubernetes/apps/network/secrets/home-assistant.yaml
@@ -1,10 +1,43 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+#
+# THE REWRITE IS LOAD-BEARING. A field name here contains a space, which is not
+# a legal Kubernetes Secret key, so without it the API server rejects the whole
+# Secret. The 1Password Operator sanitised the same way, which is why the live
+# Secret already reads with dashes — this reproduces it exactly rather than
+# approximating it with the repo's usual [\W] -> _ rule.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: home-assistant-credentials
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: home-assistant-credentials
 spec:
-    itemPath: "vaults/Eris/items/mcrhsiy556kflhq757l3mi4lwa"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: home-assistant-credentials
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/mcrhsiy556kflhq757l3mi4lwa
+        key: shared/eris-home-assistant-credentials
+      rewrite:
+        - regexp:
+            source: "[^-._a-zA-Z0-9]"
+            target: "-"

--- a/kubernetes/apps/network/traefik/crowdsec-secret.yaml
+++ b/kubernetes/apps/network/traefik/crowdsec-secret.yaml
@@ -1,9 +1,36 @@
 ---
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+#
+# Traefik mounts this Secret as a VOLUME, so every key becomes a file and the
+# key NAMES are the interface. Both exist in OpenBao under those names.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: crowdsec-secret
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: crowdsec-secret
 spec:
-    itemPath: vaults/Eris/items/Crowdsec ApiKey
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: crowdsec-secret
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Crowdsec ApiKey
+        key: shared/crowdsec-apikey

--- a/kubernetes/apps/sgc/shared/secrets/cloudflare-tunnel.yaml
+++ b/kubernetes/apps/sgc/shared/secrets/cloudflare-tunnel.yaml
@@ -1,10 +1,37 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+#
+# NOTE: this is EQUESTRIA's tunnel item, not SGC's. SGC's own token is at
+# kubernetes/apps/network/cloudflare-tunnel/secret.yaml. That crossover is
+# pre-existing and is preserved deliberately.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: cloudflare-tunnel
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: cloudflare-tunnel
 spec:
-    itemPath: vaults/Eris/items/mgksuktp4tea6hbh5kctzdmbiu
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: cloudflare-tunnel
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/mgksuktp4tea6hbh5kctzdmbiu ("Equestria Cloudflare Tunnel")
+        key: shared/equestria-cloudflare-tunnel

--- a/kubernetes/apps/sgc/shared/secrets/home-assistant.yaml
+++ b/kubernetes/apps/sgc/shared/secrets/home-assistant.yaml
@@ -1,10 +1,43 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+#
+# THE REWRITE IS LOAD-BEARING. A field name here contains a space, which is not
+# a legal Kubernetes Secret key, so without it the API server rejects the whole
+# Secret. The 1Password Operator sanitised the same way, which is why the live
+# Secret already reads with dashes — this reproduces it exactly rather than
+# approximating it with the repo's usual [\W] -> _ rule.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: home-assistant-credentials
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: home-assistant-credentials
 spec:
-    itemPath: vaults/Eris/items/mcrhsiy556kflhq757l3mi4lwa
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: home-assistant-credentials
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/mcrhsiy556kflhq757l3mi4lwa
+        key: shared/eris-home-assistant-credentials
+      rewrite:
+        - regexp:
+            source: "[^-._a-zA-Z0-9]"
+            target: "-"

--- a/kubernetes/apps/sgc/shared/secrets/media-management.yaml
+++ b/kubernetes/apps/sgc/shared/secrets/media-management.yaml
@@ -1,9 +1,42 @@
 ---
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+#
+# FIVE KEYS ARE DROPPED — credential, ersatztv_token, nextpvr_token,
+# notesPlain and username. All five render 0 bytes today: 1Password carries
+# them with EMPTY values and Phase 4 did not migrate empty-valued fields, so
+# they are absent in OpenBao. No pod, no manifest and no valuesFrom in any repo
+# reads them; checked before removing them.
+#
+# One key GAINS a real value: omdb_apikey, written into OpenBao during the
+# kometa fix (equestria-cluster#3087) where 1Password held it empty.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: media-management-credentials
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: media-management-credentials
 spec:
-    itemPath: vaults/Eris/items/Media Management Secrets
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: media-management-credentials
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Media Management Secrets
+        key: shared/media-management-secrets

--- a/kubernetes/apps/sgc/shared/secrets/truenas.yaml
+++ b/kubernetes/apps/sgc/shared/secrets/truenas.yaml
@@ -1,10 +1,33 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: truenas-credentials
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: truenas-credentials
 spec:
-    itemPath: vaults/Eris/items/nvvnzwmhywhgjf7uywkkyq7jxy
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: truenas-credentials
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/nvvnzwmhywhgjf7uywkkyq7jxy
+        key: shared/eris-truenas-credentials

--- a/kubernetes/apps/sgc/shared/secrets/unifi.yaml
+++ b/kubernetes/apps/sgc/shared/secrets/unifi.yaml
@@ -1,10 +1,33 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: unifi-credentials
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: unifi-credentials
 spec:
-    itemPath: vaults/Eris/items/dk2j2cscqjmfp3jlibkc5tx6hq
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: unifi-credentials
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/dk2j2cscqjmfp3jlibkc5tx6hq ("Unifi Discord" — the UUID resolves to a title unrelated to this Secret's name; pre-existing)
+        key: shared/unifi-discord

--- a/kubernetes/apps/tailscale-system/operator/tailscale.yaml
+++ b/kubernetes/apps/tailscale-system/operator/tailscale.yaml
@@ -1,10 +1,47 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/onepassword.com/onepassworditem_v1.json
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/external-secrets.io/externalsecret_v1.json
+#
+# Phase 7 — converted from a OnePasswordItem CR. The 1Password Operator is a
+# parallel mechanism with no OpenBao equivalent, so this is a conversion rather
+# than a `secretStoreRef` repoint.
+#
+# The Secret keeps its NAME and its KEYS: the operator wrote one Secret key per
+# 1Password field, and Phase 4 migrated the item field-for-field. Verified
+# against the live server before the change — every key matches and every value
+# is byte-identical.
+#
+# Breaks loudly: the operator resolves oauth.clientId from `username` and
+# oauth.clientSecret from `credential` via valuesFrom, so a wrong Secret fails
+# the HelmRelease, not just a pod.
+#
+# THE REWRITE IS LOAD-BEARING. A field name here contains a space, which is not
+# a legal Kubernetes Secret key, so without it the API server rejects the whole
+# Secret. The 1Password Operator sanitised the same way, which is why the live
+# Secret already reads with dashes — this reproduces it exactly rather than
+# approximating it with the repo's usual [\W] -> _ rule.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
-    name: tailscale-oauth
-    annotations:
-      reloader.stakater.com/auto: "true"
+  name: tailscale-oauth
 spec:
-    itemPath: "vaults/Eris/items/Eris Tailscale OAuth Operator"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: openbao
+  target:
+    name: tailscale-oauth
+    creationPolicy: Owner
+    template:
+      # The CR carried this annotation on itself and the operator copied it onto
+      # the Secret; on an ExternalSecret it has to be declared here.
+      metadata:
+        annotations:
+          reloader.stakater.com/auto: "true"
+  dataFrom:
+    - extract:
+        # was: vaults/Eris/items/Eris Tailscale OAuth Operator
+        key: shared/eris-tailscale-oauth-operator
+      rewrite:
+        - regexp:
+            source: "[^-._a-zA-Z0-9]"
+            target: "-"


### PR DESCRIPTION
Phase 7, the OnePasswordItem half — **all 13**. After this, **no `OnePasswordItem` manifest remains in this repo**.

Verified per CR against the live server before writing anything: for each, the live Secret’s keys and the OpenBao path’s fields were compared and every **value** checked byte-for-byte. Twelve matched exactly.

### The thirteenth, and why it is not drift

`media-management-credentials` **drops five keys** — `credential`, `ersatztv_token`, `nextpvr_token`, `notesPlain`, `username`. All five render **0 bytes** today: 1Password carries them with empty values and Phase 4 did not migrate empty-valued fields, so they are absent in OpenBao. That looked like store drift at first glance and is not — it is the same "empty is not missing" property from Phase 6, observed from the other side. No pod, no manifest and no `valuesFrom` in any repo reads them.

It also **gains** a real `omdb_apikey`, written during the kometa fix where 1Password held it empty.

### The rest

- **Four need `rewrite: [^-._a-zA-Z0-9] -> -`** because a field name contains a space, which is not a legal Secret key — without it the API server rejects the whole Secret. Reproduces the 1Password Operator’s own sanitisation exactly rather than approximating it with the repo’s usual `[\W] -> _`.
- **Two substitutions are gone on purpose.** `CLOUDFLARE_SECRET` / `CLOUDFLARE_TUNNEL_SECRET` are now literal `shared/…` paths — carrying a variable across hides whether the value is a 1Password item path or an OpenBao path, the shape that broke dynacat. Both are now unreferenced in this repo outside their sops definitions; deleting them is deliberate follow-up, matching equestria.
- **Two crossovers preserved rather than "fixed"**, both pre-existing: `sgc/cloudflare-tunnel` addresses *equestria’s* tunnel item while `network/cloudflare-tunnel` holds SGC’s own, and `unifi-credentials` resolves to an item titled *Unifi Discord*.
- `cloudflare-tunnel/ks.yaml` healthChecked the CR by kind; that reference moves to `ExternalSecret` with it.

`flate` 182 passed; every rewritten key asserted to start with a mount prefix.

**Expect on apply:** each conversion deletes an operator-owned Secret (they carry an `ownerReferences` to their CR) and recreates it under ESO, so a few seconds of absence and one transient `SecretSyncedError` apiece. Env-var consumers do not notice; the volume-mounted `crowdsec-secret` re-projects on the next kubelet sync.

<!-- crew:agent=claude -->