### PR TITLE
fix(vsc-retention): escape shell vars so envsubst leaves them alone

### DIFF
--- a/kubernetes/apps/kube-system/vsc-retention/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/vsc-retention/helmrelease.yaml
@@ -103,9 +103,9 @@ spec:
                 # -- that needs a finalizer strip, which is a human decision, not something
                 # this job does unattended. The growth alert (VolumeSnapshotContentsGrowing)
                 # is what catches that class of stall.
-                RETENTION_DAYS="${RETENTION_DAYS:-7}"
-                CUTOFF_EPOCH=$(date -u -d "-${RETENTION_DAYS} days" +%s)
-                echo "Reclaiming orphaned VolumeSnapshotContents older than ${RETENTION_DAYS} days (cutoff epoch ${CUTOFF_EPOCH})"
+                RETENTION_DAYS="$${RETENTION_DAYS:-7}"
+                CUTOFF_EPOCH=$(date -u -d "-$${RETENTION_DAYS} days" +%s)
+                echo "Reclaiming orphaned VolumeSnapshotContents older than $${RETENTION_DAYS} days (cutoff epoch $${CUTOFF_EPOCH})"
 
                 live_vscs=$(kubectl get volumesnapshots.snapshot.storage.k8s.io -A \
                   -o custom-columns='VSC:.status.boundVolumeSnapshotContentName' --no-headers 2>/dev/null \


### PR DESCRIPTION
The `vsc-retention` Kustomization has been failing for ~35h:

```
post build failed for 'HelmRelease.v2.helm.toolkit.fluxcd.io/vsc-retention':
envsubst error: variable substitution failed: variable not set (strict mode): "RETENTION_DAYS"
```

`RETENTION_DAYS` and `CUTOFF_EPOCH` are **shell** variables belonging to the job's own script — `RETENTION_DAYS` is supplied to the container via `env:`, and `CUTOFF_EPOCH` is computed at runtime by `date`. Neither is a Flux postBuild substitution. Written bare as `${...}`, Flux's envsubst claims them at build time and fails in strict mode before the manifest is ever applied.

Escaping them as `$${...}` makes envsubst emit a literal `${...}` for the shell.

This exact fix is already present on the home-operations copy of this file — equestria's `vsc-retention` is `Ready: True` — it landed there during the repo consolidation and was never backported here.

Verified no other bare `${UPPERCASE}` remains in the script block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)